### PR TITLE
Update TOML pkg requirements

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -4,4 +4,5 @@ matplotlib >= 3.3.0
 numpy >= 1.18.1
 PyQt5
 qtwidgets
-toml
+tomli
+tomli_w

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,8 @@ install_requires =
   numpy >= 1.18.1
   PyQt5
   qtwidgets
-  toml
+  tomli
+  tomli_w
 
 [options.extras_require]
 # a weird "bug" since python 2 allows extras to depend on extras


### PR DESCRIPTION
Update package requirements to require `tomli` and `tomli_w`, while dropping the dependency for `toml`.