### PR TITLE
Move `as_toml_string` functionality

### DIFF
--- a/bapsf_motion/actors/manager_.py
+++ b/bapsf_motion/actors/manager_.py
@@ -254,20 +254,7 @@ class RunManagerConfig(UserDict):
 
     @property
     def as_toml_string(self) -> str:
-        def convert_key_to_string(_d):
-            _config = {}
-            for key, value in _d.items():
-                if isinstance(value, (dict, UserDict)):
-                    value = convert_key_to_string(value)
-
-                if not isinstance(key, str):
-                    key = f"{key}"
-
-                _config[key] = value
-
-            return _config
-
-        return "[run]\n" + toml.dumps(convert_key_to_string(self))
+        return "[run]\n" + toml.as_toml_string(self)
 
     def update_run_name(self, name: str):
         if not isinstance(name, str):

--- a/bapsf_motion/actors/motion_group_.py
+++ b/bapsf_motion/actors/motion_group_.py
@@ -654,20 +654,7 @@ class MotionGroupConfig(UserDict):
 
     @property
     def as_toml_string(self) -> str:
-        def convert_key_to_string(_d):
-            _config = {}
-            for key, value in _d.items():
-                if isinstance(value, (dict, UserDict)):
-                    value = convert_key_to_string(value)
-
-                if not isinstance(key, str):
-                    key = f"{key}"
-
-                _config[key] = value
-
-            return _config
-
-        return "[motion_group]\n" + toml.dumps(convert_key_to_string(self))
+        return "[motion_group]\n" + toml.as_toml_string(self)
 
 
 class MotionGroup(EventActor):

--- a/bapsf_motion/utils/toml.py
+++ b/bapsf_motion/utils/toml.py
@@ -7,10 +7,11 @@ the appropriate packages based on the Python environment version and
 name wrangle the functionality to provide a consistent interface for
 `bapsf_motion`.
 """
-__all__ = []
+__all__ = ["as_toml_string"]
 
 import sys
 
+from collections import UserDict
 from tomli_w import *
 from tomli_w import __all__ as __rall__
 
@@ -27,4 +28,28 @@ else:
 __all__ += __rall__
 __all__ += __wall__
 
+
+def as_toml_string(config):
+    """
+    Iterate through a configuration dictionary and convert all keys to
+    strings.  This is required because `dumps` can not handle non-string
+    keys.
+    """
+    def convert_key_to_string(_d):
+        _config = {}
+        for key, value in _d.items():
+            if isinstance(value, (dict, UserDict)):
+                value = convert_key_to_string(value)
+
+            if not isinstance(key, str):
+                key = f"{key}"
+
+            _config[key] = value
+
+        return _config
+
+    return dumps(convert_key_to_string(config))
+
+
+# cleanup namespace
 del sys, __rall__, __wall__


### PR DESCRIPTION
Move functionality `as_toml_string` from `RunManagerConfig` and `MotionGroupConfig` to `bapsf_motion.utils.toml`.  This allows for the functionality to be more universally used.

This functionality is required because our configuration dictionaries used non-string keys, and the base `toml.dump` and `toml.dumps` does not automatically convert these keys to strings.