### PR TITLE
Fix out of sync commands

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1202,8 +1202,11 @@ class Motor(EventActor):
 
         """
         self._send(cmd)
-        data = self._recv()
-        return data.decode("ASCII")
+
+        if not self.status["connected"]:
+            return self.ack_flags.LOST_CONNECTION
+
+        return self._recv().decode("ASCII")
 
     def _send(self, cmd: str):
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1248,6 +1248,7 @@ class Motor(EventActor):
         _eom = b"\r"  # end of message
 
         cmd_str = _header + bytes(cmd.encode("ASCII")) + _eom
+        self.logger.debug(f"Sending command string '{cmd_str}'.")
         try:
             self.socket.sendall(cmd_str)
         except (ConnectionError, OSError) as err:
@@ -1309,6 +1310,7 @@ class Motor(EventActor):
                 msg = msg.split(_eom)[0]
                 break
 
+        self.logger.debug(f"Received string '{msg}'.")
         return msg
 
     def retrieve_motor_status(self, direct_send=False):

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -980,7 +980,7 @@ class Motor(EventActor):
             if recv_str == self.ack_flags.LOST_CONNECTION:
                 raise ConnectionError("Lost connection to motor.")
 
-            _rtn = self._process_command_return(command, recv_str)
+            _rtn = self._process_command_return_string(command, recv_str)
 
             if (
                 len(args) == 0
@@ -1007,7 +1007,7 @@ class Motor(EventActor):
                     _rtn = self.ack_flags.LOST_CONNECTION
                     break
                 recv_str = recv.decode("ASCII")
-                _rtn = self._process_command_return(command, recv_str)
+                _rtn = self._process_command_return_string(command, recv_str)
 
         except (ConnectionError, TimeoutError, OSError) as err:
             # Note: if the Ack/Nack protocol is not properly set (see method
@@ -1128,7 +1128,7 @@ class Motor(EventActor):
 
         return cmd_str + processor(args[0])
 
-    def _process_command_return(self, command: str, rtn_str: str) -> Any:
+    def _process_command_return_string(self, command: str, rtn_str: str) -> Any:
         """
         Process the returned string from the sent motor command.  The
         regular expression pattern for matching the returned string
@@ -1153,7 +1153,7 @@ class Motor(EventActor):
         Examples
         --------
 
-        >>> self._process_command_return("speed", "VE 5.500")
+        >>> self._process_command_return_string("speed", "VE 5.500")
         5.5
 
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1251,7 +1251,8 @@ class Motor(EventActor):
 
             self._update_status(connected=False)
             self.connect()
-            self.socket.sendall(cmd_str)
+            if self.status["connected"]:
+                self.socket.sendall(cmd_str)
 
     def _recv(self) -> AnyStr:
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1218,10 +1218,15 @@ class Motor(EventActor):
         """
         self._send(cmd)
 
-        if not self.status["connected"]:
+        try:
+            return self._recv().decode("ASCII")
+        except TimeoutError as err:
+            self.logger.warning(
+                f"Lost connection while trying to receive response to "
+                f"commend '{cmd}'.",
+                exc_info=err,
+            )
             return self.ack_flags.LOST_CONNECTION
-
-        return self._recv().decode("ASCII")
 
     def _send(self, cmd: str):
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -996,13 +996,16 @@ class Motor(EventActor):
                 self.logger.info("Connection re-established.")
             else:
                 _rtn = self._process_command_return(command, recv_str)
+
         except (ConnectionError, TimeoutError, OSError) as err:
             # Note: if the Ack/Nack protocol is not properly set (see method
             #       read_and_set_protocol(), then TimeoutErrors can occur
             #       even if the connection is still established.
             #
-            self.logger.error(f"{err.__class__.__name__}: {err}")
-            self.logger.error(f"Last command '{command}' was not executed.")
+            self.logger.error(
+                f"Last command '{command}' was not executed.",
+                exc_info=err,
+            )
 
             _rtn = self.ack_flags.LOST_CONNECTION
             self._update_status(connected=False)
@@ -1229,7 +1232,7 @@ class Motor(EventActor):
         try:
             self.socket.sendall(cmd_str)
         except (ConnectionError, OSError) as err:
-            self.logger.error(f"{err.__class__.__name__}: {err}")
+            self.logger.error(f"Unable to send command {cmd_str}.", exc_info=err)
             if err.errno == errno.EPIPE:
                 self.logger.error(
                     "It appears the server (motor) has closed the connection."


### PR DESCRIPTION
Received strings (from the physical motor) were routinely cumming "out of sync" with the sent command.  This was routinely happening when the heartbeat performed the `retrieve_motor_status()`.  It turned out that the motor would send an ACK string `%` to confirm the reception of a buffered command like `request status RS`, and then follow up with the full response string.  The `Motor` class was expecting the first response from the motor to be the final response.  This PR updates the functionality of `Motor._send_command` such that repeats the `socket.recv()` until the expected response is received or and `TimeoutError` occurs.  The `TimeoutError` indicates the motor has executed all the commands in its buffer and we missed the expected response.