### PR TITLE
Fix `as_toml_string` generator

### DIFF
--- a/bapsf_motion/actors/manager_.py
+++ b/bapsf_motion/actors/manager_.py
@@ -254,7 +254,7 @@ class RunManagerConfig(UserDict):
 
     @property
     def as_toml_string(self) -> str:
-        return "[run]\n" + toml.as_toml_string(self)
+        return toml.as_toml_string({"run": self})
 
     def update_run_name(self, name: str):
         if not isinstance(name, str):

--- a/bapsf_motion/actors/motion_group_.py
+++ b/bapsf_motion/actors/motion_group_.py
@@ -654,7 +654,7 @@ class MotionGroupConfig(UserDict):
 
     @property
     def as_toml_string(self) -> str:
-        return "[motion_group]\n" + toml.as_toml_string(self)
+        return toml.as_toml_string({"motion_group": self})
 
 
 class MotionGroup(EventActor):


### PR DESCRIPTION
Previous incarnation was incorrectly generating the TOML string like...

``` python
"[run]\n" + bapsf_motion.utils.toml.as_toml_string(config)
```

which produced a TOML structure like...

``` toml
[run]
...

[motion_group]
...
```

However, the TOML structure should look like...
``` toml
[run]
...

[run.motion_group]
...
```

This is easily address by doing the following instead...

``` python
bapsf_motion.utils.toml.as_toml_string({"run" : config})
```

----

The previous incarnation generated an invalid TOML, which would cause the `RunManager` to rejection the motion group configurarion.

