### PR TITLE
Set upper dependency bound (`<= 3.4.5`) on `sphinx-tabs` 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ sphinx:
 
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: requirements/docs.txt
     - method: pip
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,10 +84,6 @@ automodapi_groups_with_inheritance_diagrams = [
     "warnings",
 ]
 
-# If your documentation needs a minimal Sphinx version, state it here.
-
-needs_sphinx = "4.4"
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones. When extensions are removed or added, please update the section

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -19,7 +19,7 @@ sphinx-issues >= 3.0.1
 sphinx-notfound-page >= 0.8.3
 sphinx-reredirects >= 0.1.1
 sphinx_rtd_theme >= 1.2.0
-sphinx_tabs >= 3.4.1
+sphinx_tabs >= 3.4.1, <= 3.4.5
 sphinxcontrib-bibtex >= 2.5.0
 towncrier >= 22.12
 tox >= 4.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ docs =
   sphinx-notfound-page >= 0.8.3
   sphinx-reredirects >= 0.1.1
   sphinx_rtd_theme >= 1.2.0
-  sphinx_tabs >= 3.4.1
+  sphinx_tabs >= 3.4.1, <= 3.4.5
   sphinxcontrib-bibtex >= 2.5.0
   towncrier >= 22.12
   tox >= 4.4.0


### PR DESCRIPTION
Changes made in https://github.com/executablebooks/sphinx-tabs/pull/198 are causing the `tabs.css` to not be included when a page is build.  I'm currently not sure what the exact culprit is.  `v3.4.5` still properly includes the CSS.

For version `>3.4.5` the tabs should up as regular html buttons...
![image](https://github.com/user-attachments/assets/fa8780c7-012c-49bd-956c-7267673eb9cd)

Instead of...
![image](https://github.com/user-attachments/assets/a8eba4cb-538d-4841-acd4-e7853dddca85)
