### PR TITLE
Make 32bit dependencies the default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,9 +160,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
-      - name: Platform architecture
-        run: |
-          python -c "import platform; print(platform.machine())"
       - name: Install 'bapsf_motion' dependencies
         if: ${{ matrix.architecture == 'x64' }}
         run: |
@@ -174,7 +171,7 @@ jobs:
       - name: Install 'bapsf_motion' dependencies (32bit)
         if: ${{ matrix.architecture == 'x86' }}
         run: |
-          python -m pip install -r requirements/install-32bit.txt
+          python -m pip install -r requirements/install.txt
       - name: Import 'bapsf_motion'
         run: |
           python -c 'import bapsf_motion'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
+      - name: Platform architecture
+        run: |
+          python -c "import platform; print(platform.machine())"
       - name: Install 'bapsf_motion' dependencies
         if: ${{ matrix.architecture == 'x64' }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ auto_examples
 plasmapy/version.py
 tags
 docs/notebooks/*.md
+
+.git/

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -1,5 +1,5 @@
 # these are dependencies required to use the package on a 32-bit version of Python
 # pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
 pandas <= 2.0.3
-matplotlib >= 3.3.0, <= 3.9.0
+matplotlib >= 3.3.0, < 3.9.0
 -r install.txt

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -1,5 +1,5 @@
 # these are dependencies required to use the package on a 32-bit version of Python
 # pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
--r install.txt
 pandas <= 2.0.3
-matplotlib <= 3.9.0
+matplotlib >= 3.3.0, <= 3.9.0
+-r install.txt

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -2,4 +2,4 @@
 # pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
 -r install.txt
 pandas <= 2.0.3
-matplotlib <= 3.9.2
+matplotlib <= 3.9.0

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -1,6 +1,0 @@
-# these are dependencies required to use the package on a 32-bit version of Python
-# pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
-pandas <= 2.0.3
-matplotlib >= 3.3.0, < 3.9.0
-numpy >= 1.18.1, < 2.0
--r install.txt

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -2,4 +2,5 @@
 # pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
 pandas <= 2.0.3
 matplotlib >= 3.3.0, < 3.9.0
+numpy >= 1.18.1, < 2.0
 -r install.txt

--- a/requirements/install-32bit.txt
+++ b/requirements/install-32bit.txt
@@ -2,3 +2,4 @@
 # pandas 2.1+ does NOT successfully install on a 32-bit python while on a 64-bt platform
 -r install.txt
 pandas <= 2.0.3
+matplotlib <= 3.9.2

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,10 +1,14 @@
 # these are dependencies required to use the package
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 -r build.txt
+# restrictions due to supporting 32bit architecture
+# - PEP508 does not allow for architecture based dependencies
+matplotlib >= 3.3.0, < 3.9.0
+numpy >= 1.18.1, < 2.0
+pandas <= 2.0.3
+# normal dependencies...these must follow the 32bit dependencies
 astropy
 importlib_metadata; python_version < '3.8'
-matplotlib >= 3.3.0
-numpy >= 1.18.1
 numpydoc
 tomli; python_version < '3.11'
 tomli_w

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -4,6 +4,7 @@
 astropy
 importlib_metadata; python_version < '3.8'
 matplotlib >= 3.3.0
+matplotlib <= 3.9.0; platform_machine == 'x86'
 numpy >= 1.18.1
 numpydoc
 tomli; python_version < '3.11'

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,7 +3,6 @@
 -r build.txt
 astropy
 importlib_metadata; python_version < '3.8'
-matplotlib >= 3.3.0, <= 3.9.0; platform_machine == 'x86'
 matplotlib >= 3.3.0
 numpy >= 1.18.1
 numpydoc

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,8 +3,8 @@
 -r build.txt
 astropy
 importlib_metadata; python_version < '3.8'
+matplotlib >= 3.3.0, <= 3.9.0; platform_machine == 'x86'
 matplotlib >= 3.3.0
-matplotlib <= 3.9.0; platform_machine == 'x86'
 numpy >= 1.18.1
 numpydoc
 tomli; python_version < '3.11'

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
   astropy
   importlib_metadata; python_version < '3.8'
   matplotlib >= 3.3.0
+  matplotlib <= 3.9.0; platform_machine == 'x86'
   numpy >= 1.18.1
   numpydoc
   tomli; python_version < '3.11'

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,15 +41,22 @@ setup_requires =
   # build dependencies...they should be defined under build-system.requires
 install_requires =
   # ought to mirror requirements/install.txt
+  #
+  # restrictions due to supporting 32bit architecture
+  # - PEP508 does not allow for architecture based dependencies
+  # - the 32bit restrictions determine the upper bound
+  matplotlib >= 3.3.0, < 3.9.0
+  numpy >= 1.18.1, < 2.0
+  pandas <= 2.0.3
+  # normal dependencies...these must follow the 32bit dependencies
   astropy
   importlib_metadata; python_version < '3.8'
-  matplotlib >= 3.3.0
-  numpy >= 1.18.1
   numpydoc
   tomli; python_version < '3.11'
   tomli_w
   tqdm
   xarray
+
 dependency_links =
   # https://setuptools.pypa.io/en/latest/deprecated/dependency_links.html?highlight=dependency_links
   git+https://github.com/PlasmaPy/plasmapy_sphinx@main#egg=plasmapy_sphinx
@@ -66,11 +73,7 @@ gui =
 tests =
   # ought to mirror requirements/tests.txt
   pytest >= 5.1
-32bit =
-  # ought to mirror requirements/install-32bit.txt
-  pandas <= 2.0.3
-  matplotlib >= 3.3.0, < 3.9.0
-  numpy >= 1.18.1, < 2.0
+
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ install_requires =
   # ought to mirror requirements/install.txt
   astropy
   importlib_metadata; python_version < '3.8'
+  matplotlib >= 3.3.0, <= 3.9.0; platform_machine == 'x86'
   matplotlib >= 3.3.0
-  matplotlib <= 3.9.0; platform_machine == 'x86'
   numpy >= 1.18.1
   numpydoc
   tomli; python_version < '3.11'

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ tests =
   # ought to mirror requirements/install-32bit.txt
   pandas <= 2.0.3
   matplotlib >= 3.3.0, < 3.9.0
+  numpy >= 1.18.1, < 2.0
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ tests =
 32bit =
   # ought to mirror requirements/install-32bit.txt
   pandas <= 2.0.3
-  matplotlib <= 3.9.2
+  matplotlib <= 3.9.0
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ tests =
 32bit =
   # ought to mirror requirements/install-32bit.txt
   pandas <= 2.0.3
-  matplotlib >= 3.3.0, <= 3.9.0
+  matplotlib >= 3.3.0, < 3.9.0
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
   # ought to mirror requirements/install.txt
   astropy
   importlib_metadata; python_version < '3.8'
-  matplotlib >= 3.3.0, <= 3.9.0; platform_machine == 'x86'
   matplotlib >= 3.3.0
   numpy >= 1.18.1
   numpydoc
@@ -70,7 +69,7 @@ tests =
 32bit =
   # ought to mirror requirements/install-32bit.txt
   pandas <= 2.0.3
-  matplotlib <= 3.9.0
+  matplotlib >= 3.3.0, <= 3.9.0
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ tests =
 32bit =
   # ought to mirror requirements/install-32bit.txt
   pandas <= 2.0.3
+  matplotlib <= 3.9.2
 docs =
   # ought to mirror requirements/docs.txt
   docutils >= 0.18.1


### PR DESCRIPTION
[PEP-508](https://peps.python.org/pep-0508/) does not allow for specifiers to install dependencies based on the Python architecture, and pip does not seem eager to adopt anything until PEP-508 is updated (https://github.com/pypa/pipenv/issues/2397).  Thus, I'm currently restricting install dependencies to what is currently deplorable on a 32bit architecture.

`bapsf_motion` can run fine on 32-bit and 64-bit architecture.  We only need to keep support for 32-bit architecture due to the legacy deployment on the LaPD ACQ II system.