### PR TITLE
Fix handling of `inf` and `nan` input in the Configuration GUI

### DIFF
--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -818,7 +818,6 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
                 )
                 _input = None
                 input_widget.setText("")
-                raise
 
         self._param_inputs[param] = _input
 
@@ -969,7 +968,6 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
                 exc_info=err,
             )
             self.change_validation_state(False)
-            raise
 
     def change_validation_state(self, valid: bool = False):
         self.params_add_btn.setEnabled(valid)

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -802,6 +802,20 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         _type = self._param_inputs["_type"]
         _registry = self._param_inputs["_registry"]
 
+        # Handle strings representing np.inf and np.nan
+        for np_repr in ("inf", "nan"):
+            single_quote_string = f"'{np_repr}'"
+            double_quote_string = f'"{np_repr}"'
+            if (
+                np_repr in _input_string
+                and not (
+                    single_quote_string in _input_string
+                    or double_quote_string in _input_string
+                )
+            ):
+                _input_string = _input_string.replace(np_repr, single_quote_string)
+                input_widget.setText(_input_string)
+
         try:
             _input = ast.literal_eval(_input_string)
         except (ValueError, SyntaxError) as err:

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -804,7 +804,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         try:
             _input = ast.literal_eval(_input_string)
-        except (ValueError, SyntaxError):
+        except (ValueError, SyntaxError) as err:
             params = _registry.get_input_parameters(_type)
             _type = params[param]["param"].annotation
             if inspect.isclass(_type) and issubclass(_type, str):
@@ -813,7 +813,8 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
                 _input = None
             else:
                 self.logger.exception(
-                    f"Input '{input_widget.text()}' is not a valid type for '{param}'."
+                    f"Input '{input_widget.text()}' is not a valid type for '{param}'.",
+                    exc_info=err,
                 )
                 _input = None
                 input_widget.setText("")

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -963,8 +963,11 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             )
             # self._transform = transform
             self.change_validation_state(True)
-        except (ValueError, TypeError):
-            self.logger.exception("Supplied input arguments are not valid.")
+        except (ValueError, TypeError) as err:
+            self.logger.exception(
+                "Supplied input arguments are not valid.",
+                exc_info=err,
+            )
             self.change_validation_state(False)
             raise
 

--- a/bapsf_motion/motion_builder/exclusions/divider.py
+++ b/bapsf_motion/motion_builder/exclusions/divider.py
@@ -144,7 +144,7 @@ class DividerExclusion(BaseExclusion):
         elif len(self.mb) != 2:
             raise TypeError
         elif (
-            isinstance(self.mb[0], str) and self.mb[0] == "inf"
+            isinstance(self.mb[0], str) and "inf" in self.mb[0]
         ) or np.isinf(self.mb[0]):
             if not isinstance(self.mb[1], _scalar_types):
                 raise ValueError


### PR DESCRIPTION
In the Configuration GUI, for inputs of `inf` and `nan` into single quote strigns, `'inf'` and `'nan'` respectively.  This prevents `ast.literal_eval()` from throwing exceptions.  The respective functionality (e.g. `GridLayer` should convert the string to its `numpy` counterpart).