### PR TITLE
Fix behavior of the Configure GUI dropdown menus

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2157,6 +2157,39 @@ class MGWidget(QWidget):
                 count = self.transform_dropdown.count()
                 self.transform_dropdown.setItemIcon(count-1, _template_icon)
 
+        if (
+            isinstance(self.mg, MotionGroup)
+            and isinstance(self.mg.transform, BaseTransform)
+        ):
+            _type = self.mg.transform.transform_type
+            _config = _deepcopy_dict(self.mg.transform.config)
+            if (
+                tr_config_stored is None
+                or tr_config_stored["type"] != _type
+                or not dict_equal(tr_config_stored, _config)
+            ):
+                tr_name_stored = _type
+
+            for ii, _item in enumerate(self.transform_defaults):
+                tr_name = _item[0]
+                tr_default_config = _item[1]
+
+                if _type != tr_default_config["type"]:
+                    continue
+
+                index = self.transform_dropdown.findText(tr_name)
+                if index == -1:
+                    # this should not happen
+                    break
+
+                self._transform_defaults[ii] = (
+                    tr_name,
+                    {**tr_default_config, **_config},
+                )
+                self.transform_dropdown.setCurrentIndex(index)
+                self.transform_dropdown.blockSignals(False)
+                return
+
         if tr_name_stored is not None:
             index = self.transform_dropdown.findText(tr_name_stored)
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2669,7 +2669,7 @@ class MGWidget(QWidget):
     @Slot(int)
     def _transform_dropdown_new_selection(self, index):
         tr_name = self.transform_dropdown.currentText()
-        self.logger.warning(f"New selections in transform dropdown {index} '{tr_name}'")
+        self.logger.info(f"New selections in transform dropdown {index} '{tr_name}'")
 
         if index == -1:
             return

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2424,10 +2424,12 @@ class MGWidget(QWidget):
         self.logger.info("Spawning Motion Group")
 
         if isinstance(self.mg, MotionGroup):
+            self.logger.info("Terminating Motion Group for re-spawn.")
             self.mg.terminate(delay_loop_stop=True)
             # self._set_mg(None)
             self._mg = None
 
+        mg = None
         try:
             mg = MotionGroup(
                 config=self.mg_config,
@@ -2435,8 +2437,16 @@ class MGWidget(QWidget):
                 loop=self.mg_loop,
                 auto_run=True,
             )
-        except (ConnectionError, TimeoutError, ValueError, TypeError):
-            self.logger.warning("Not able to instantiate MotionGroup.")
+        except (ConnectionError, TimeoutError, ValueError, TypeError) as err:
+            self.logger.warning(
+                "Not able to instantiate MotionGroup.",
+                exc_info=err,
+            )
+            try:
+                mg.terminate(delay_loop_stop=True)
+            except AttributeError:
+                pass
+
             mg = None
 
         # modify drive_dropdown

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2048,6 +2048,7 @@ class MGWidget(QWidget):
 
         self.mb_dropdown.clear()
 
+        # get space dimensionality
         if isinstance(self.mg, MotionGroup) and isinstance(self.mg.drive, Drive):
             naxes = self.mg.drive.naxes
         elif "drive" in self.mg_config and "axes" in self.mg_config["drive"]:

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1510,7 +1510,11 @@ class MGWidget(QWidget):
         deployed_ips = []
         if isinstance(self._parent.rm, RunManager):
             for mg in self._parent.rm.mgs.values():
-                if mg_config is not None and dict_equal(mg_config, mg.config):
+                if (
+                    mg_config is not None
+                    and mg_config["name"] == mg.config["name"]
+                    and dict_equal(mg_config, mg.config)
+                ):
                     # assume we are editing an existing motion group
                     continue
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2174,7 +2174,7 @@ class MGWidget(QWidget):
                 tr_name = _item[0]
                 tr_default_config = _item[1]
 
-                if _type != tr_default_config["type"]:
+                if tr_name_stored != tr_default_config["type"]:
                     continue
 
                 index = self.transform_dropdown.findText(tr_name)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2316,7 +2316,6 @@ class MGWidget(QWidget):
         self.logger.info(f"Replacing the motion group's transform...\n{config}")
         if not bool(config):
             # config is empty
-            self.mg.terminate(delay_loop_stop=True)
             self.drive_control_widget.setEnabled(False)
             self.transform_btn.set_invalid()
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1524,7 +1524,7 @@ class MGWidget(QWidget):
             "ips": deployed_ips,
         }
 
-        self._logger = gui_logger
+        self._logger = logging.getLogger(f"{gui_logger.name}.MGW")
 
         self._mg = None
         self._mg_index = None
@@ -2398,7 +2398,7 @@ class MGWidget(QWidget):
         try:
             mg = MotionGroup(
                 config=self.mg_config,
-                logger=logging.getLogger(f"{self.logger.name}.MGW"),
+                logger=logging.getLogger(f"{self.logger.name}.MG"),
                 loop=self.mg_loop,
                 auto_run=True,
             )

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2629,7 +2629,7 @@ class MGWidget(QWidget):
         if index == -1:
             return
         elif mb_name == "Custom Motion Builder":
-            # custom transform can be anything, change nothing
+            # custom mb can be anything, change nothing
             return
 
         mb_default_config = None  # type: Union[Dict[str, Any], None]

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2356,7 +2356,7 @@ class MGWidget(QWidget):
 
     @Slot(object)
     def _change_motion_builder(self, config: Dict[str, Any]):
-        self.logger.info("Replacing the motion group's motion builder.")
+        self.logger.info(f"Replacing the motion group's motion builder.\n{config}")
         self.mg.replace_motion_builder(_deepcopy_dict(config))
         self.configChanged.emit()
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1546,6 +1546,7 @@ class MGWidget(QWidget):
         self._build_transform_defaults()
 
         self._mb_defaults = None
+        self._custom_mb_index = -1
         self._build_mb_defaults()
 
         # Define TEXT WIDGETS
@@ -1890,6 +1891,7 @@ class MGWidget(QWidget):
         return self._drive_defaults
 
     def _build_mb_defaults(self):
+        self._custom_mb_index = 0
         if self._defaults is None or "motion_builder" not in self._defaults:
             self._mb_defaults = [("Custom Motion Builder", {})]
             return self._mb_defaults
@@ -1928,6 +1930,9 @@ class MGWidget(QWidget):
         for key, val in _mb_defaults_dict.items():
             if key == default_name:
                 self._mb_defaults.insert(0, (key, val))
+
+                if key != "Custom Motion Builder":
+                    self._custom_mb_index = 1
             else:
                 self._mb_defaults.append((key, val))
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2022,6 +2022,9 @@ class MGWidget(QWidget):
         # set drive
         self.drive_dropdown.blockSignals(True)
         drive_index = 0
+        if isinstance(self.mg, MotionGroup) and isinstance(self.mg.drive, Drive):
+            drive_name = self.mg.drive.config["name"]
+            drive_index = self.drive_dropdown.findText(drive_name)
         self.drive_dropdown.setCurrentIndex(drive_index)
 
         self.drive_dropdown.blockSignals(False)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2404,6 +2404,34 @@ class MGWidget(QWidget):
         self.drive_dropdown.setCurrentIndex(index)
 
     def _update_mb_dropdown(self):
+        self.logger.info("Updating MB dropdown")
+        if isinstance(self.mg, MotionGroup) and isinstance(self.mg.mb, MotionBuilder):
+            mb_config = _deepcopy_dict(self.mg.mb.config)
+            mb_dropdown_index = self.mb_dropdown.currentIndex()
+            mb_dropdown_name = self.mb_defaults[mb_dropdown_index][0]
+            mb_dropdown_config = self.mb_defaults[mb_dropdown_index][1]
+
+            if mb_dropdown_name == "Custom Motion Builder":
+                # update the custom motion builder with the current config
+                self.mb_defaults[mb_dropdown_index] = (mb_dropdown_name, mb_config)
+            elif dict_equal(mb_config, mb_dropdown_config):
+                # the config for the pre-defined motion builder matches the
+                # deployed config
+                pass
+            else:
+                # the config for the pre-defined motion builder does NOT match
+                # the deployed config...switch to custom motion builder
+                self.mb_dropdown.blockSignals(True)
+
+                self.mb_defaults[self._custom_mb_index] = (
+                    "Custom Motion Builder", mb_config
+                )
+
+                self._mb_combo_last_index = self._custom_mb_index
+                self.mb_dropdown.setCurrentIndex(self._custom_mb_index)
+
+                self.mb_dropdown.blockSignals(False)
+
         self._populate_mb_dropdown()
 
     def _update_transform_dropdown(self):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1846,15 +1846,34 @@ class MGWidget(QWidget):
         if "name" in _defaults.keys():
             # only one drive defined
             _name = _defaults["name"]
-            if _name not in _drive_defaults.keys():
+
+            # exclude drives that are already deployed
+            exclude = False
+            ips = [ax["ip"] for ax in _defaults["axes"].values()]
+            if (
+                len(set(ips) - set(self._deployed_restrictions["ips"])) != len(ips)
+            ):
+                exclude = True
+
+            # add to defaults
+            if not exclude and _name not in _drive_defaults.keys():
                 _drive_defaults[_name] = _deepcopy_dict(_defaults)
         else:
             for key, entry in _defaults.items():
                 _name = entry["name"]
+
+                # do not add duplicate defaults
                 if _name in _drive_defaults.keys():
-                    # do not add duplicate defaults
                     continue
 
+                # exclude drives that are already deployed
+                ips = [ax["ip"] for ax in entry["axes"].values()]
+                if (
+                    len(set(ips) - set(self._deployed_restrictions["ips"])) != len(ips)
+                ):
+                    continue
+
+                # add to defaults
                 _drive_defaults[_name] = _deepcopy_dict(entry)
 
         # convert to list of 2-element tuples

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2019,8 +2019,12 @@ class MGWidget(QWidget):
 
             self.drive_dropdown.addItem(drive_name)
 
-        # set default drive
-        self.drive_dropdown.setCurrentIndex(0)
+        # set drive
+        self.drive_dropdown.blockSignals(True)
+        drive_index = 0
+        self.drive_dropdown.setCurrentIndex(drive_index)
+
+        self.drive_dropdown.blockSignals(False)
 
     def _populate_mb_dropdown(self):
         self.logger.info("Populating Motion Builder dropdown")

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -108,21 +108,21 @@ def _deepcopy_dict(item):
 
 
 def dict_equal(d1, d2) -> bool:
+    if not isinstance(d1, (dict, UserDict)) or not isinstance(d2, (dict, UserDict)):
+        return False
+
     if set(d1) != set(d2):
         return False
 
     for key, val in d1.items():
-        if key not in d2:
-            return False
-
         if isinstance(val, (dict, UserDict)):
             equality = dict_equal(val, d2[key])
-            return equality
 
-        if val == d2[key]:
-            continue
+            if not equality:
+                return False
 
-        return False
+        if val != d2[key]:
+            return False
 
     return True
 

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -107,7 +107,7 @@ def _deepcopy_dict(item):
     return _copy
 
 
-def dict_equal(d1, d2):
+def dict_equal(d1, d2) -> bool:
     if set(d1) != set(d2):
         return False
 
@@ -119,7 +119,12 @@ def dict_equal(d1, d2):
             equality = dict_equal(val, d2[key])
             return equality
 
-        return val == d2[key]
+        if val == d2[key]:
+            continue
+
+        return False
+
+    return True
 
 
 def loop_safe_stop(loop: asyncio.AbstractEventLoop, max_wait: Optional[float] = 6.0):


### PR DESCRIPTION
The PR tries to address some observed inconsistent behavior of the Drive, Motion Builder, and Transform drop-downs of the Configure GUI.

### Drove Drop-Down

- Any predefined drives that share IPs with deployed motion groups are automatically filtered out.
- The "Custom Drive" entry if replaced with the Drive name once the drive is fully defined.  This name will keep updating with subsequent edits/updates.

### Motion Builder Drop-Down

- If a predefined motion builder config is edited and returned, then the drop-down will automatically switch to a `"Custom Motion Builder"`, leaving the predefined config unchanged.
- The default config for `"Custom Motion Builder"` is always updated with the latest valid configuration.  It starts as a null config, but updates with each edit.

### Transform Drop-Down

- Removed the concept of a `"Custom Transform"`.
- If a not-fully configured transform is selected from the drop-down, the drive will not be invalidated.
- If a base transform is selected and then fully configured, then that configuration will be stored as the base transform configuration for the rest of the session (of that motion group).
- If a predefined transform is edited, then the indicated transform in the drop-down will switch to the base transform and leave the predefined transform untouched.