### PR TITLE
Fix `dict_equal()`

### DIFF
--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -108,21 +108,21 @@ def _deepcopy_dict(item):
 
 
 def dict_equal(d1, d2) -> bool:
+    if not isinstance(d1, (dict, UserDict)) or not isinstance(d2, (dict, UserDict)):
+        return False
+
     if set(d1) != set(d2):
         return False
 
     for key, val in d1.items():
-        if key not in d2:
-            return False
-
         if isinstance(val, (dict, UserDict)):
             equality = dict_equal(val, d2[key])
-            return equality
 
-        if val == d2[key]:
-            continue
+            if not equality:
+                return False
 
-        return False
+        if val != d2[key]:
+            return False
 
     return True
 

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -107,7 +107,7 @@ def _deepcopy_dict(item):
     return _copy
 
 
-def dict_equal(d1, d2):
+def dict_equal(d1, d2) -> bool:
     if set(d1) != set(d2):
         return False
 
@@ -119,7 +119,12 @@ def dict_equal(d1, d2):
             equality = dict_equal(val, d2[key])
             return equality
 
-        return val == d2[key]
+        if val == d2[key]:
+            continue
+
+        return False
+
+    return True
 
 
 def loop_safe_stop(loop: asyncio.AbstractEventLoop, max_wait: Optional[float] = 6.0):


### PR DESCRIPTION
`dict_equal()` was incorrectly returning on the first comparison of the first item in the dict.  Code is update to ensure we scan through all dictionary items.