### PR TITLE
Add Display for the Motion Space

### DIFF
--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -358,7 +358,7 @@ class ConfigureGUI(QMainWindow):
         return self._logging_config_dict
 
     def replace_rm(self, config):
-        if isinstance(self.rm, RunManager) and not self.rm.terminated:
+        if isinstance(self.rm, RunManager):
             self.rm.terminate()
 
         self.logger.info(f"Replacing the run manager with new config: {config}.")

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -741,7 +741,7 @@ class DriveBaseController(QWidget):
         return position
 
     @property
-    def target_position(self):
+    def target_position(self) -> Union[List[float], None]:
         target_position = []
         for acw in self._axis_control_widgets:
             if acw.isHidden():

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1821,6 +1821,9 @@ class MGWidget(QWidget):
 
         self.drive_control_widget.movementStarted.connect(self.disable_config_controls)
         self.drive_control_widget.movementStopped.connect(self.enable_config_controls)
+        self.drive_control_widget.targetPositionChanged.connect(
+            self.mpl_canvas.update_target_position_plot
+        )
 
         self.done_btn.clicked.connect(self.return_and_close)
         self.discard_btn.clicked.connect(self.close)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -289,6 +289,7 @@ class AxisControlWidget(QWidget):
     movementStarted = Signal(int)
     movementStopped = Signal(int)
     axisStatusChanged = Signal()
+    targetPositionChanged = Signal(float)
 
     def __init__(
         self,
@@ -393,6 +394,9 @@ class AxisControlWidget(QWidget):
         self.jog_backward_btn.clicked.connect(self.jog_backward)
         self.zero_btn.clicked.connect(self._zero_axis)
         self.jog_delta_label.editingFinished.connect(self._validate_jog_value)
+        self.target_position_label.editingFinished.connect(
+            self._validate_target_position_value
+        )
 
     def _define_layout(self):
         layout = QVBoxLayout()
@@ -571,6 +575,14 @@ class AxisControlWidget(QWidget):
         val = 0.0 if _txt == "" else float(_txt)
         val = abs(val)
         self.jog_delta_label.setText(f"{val:.2f}")
+
+    def _validate_target_position_value(self):
+        try:
+            val = self.target_position
+        except ValueError:
+            val = None
+
+        self.targetPositionChanged.emit(val)
 
     def _zero_axis(self):
         self.logger.info(f"Setting zero of axis {self.axis_index}")

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1318,6 +1318,7 @@ class DriveGameController(DriveBaseController):
 class DriveControlWidget(QWidget):
     movementStarted = Signal()
     movementStopped = Signal()
+    driveStatusChanged = Signal()
     targetPositionChanged = Signal(list)
 
     def __init__(self, parent=None):
@@ -1385,6 +1386,9 @@ class DriveControlWidget(QWidget):
         self.desktop_controller_widget.moveTo.connect(self._move_to)
         self.desktop_controller_widget.targetPositionChanged.connect(
             self.targetPositionChanged.emit
+        )
+        self.desktop_controller_widget.driveStatusChanged.connect(
+            self.driveStatusChanged.emit
         )
 
         self.controller_combo_box.currentTextChanged.connect(self._switch_stack)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -710,6 +710,9 @@ class DriveBaseController(QWidget):
         self.movementStarted.connect(self.disable_motion_buttons)
         self.movementStopped.connect(self.enable_motion_buttons)
 
+        for acw in self._axis_control_widgets:
+            acw.targetPositionChanged.connect(self._target_position_changed)
+
     @abstractmethod
     def _define_layout(self) -> QLayout:
         ...

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -730,6 +730,17 @@ class DriveBaseController(QWidget):
         return self._mspace_drive_polarity
 
     @property
+    def position(self) -> List[float]:
+        position = []
+        for acw in self._axis_control_widgets:
+            if acw.isHidden():
+                continue
+
+            position.append(acw.position.value)
+
+        return position
+
+    @property
     def target_position(self):
         target_position = []
         for acw in self._axis_control_widgets:

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -725,6 +725,25 @@ class DriveBaseController(QWidget):
     def mspace_drive_polarity(self):
         return self._mspace_drive_polarity
 
+    @property
+    def target_position(self):
+        target_position = []
+        for acw in self._axis_control_widgets:
+            if acw.isHidden():
+                continue
+
+            target_position.append(acw.target_position)
+
+        if not bool(target_position):
+            # no values in target position
+            return None
+
+        if any(pos is None for pos in target_position):
+            # some target positions are not valid
+            return None
+
+        return target_position
+
     def link_motion_group(self, mg: MotionGroup):
         if not isinstance(mg, MotionGroup):
             self.logger.warning(

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1307,6 +1307,7 @@ class DriveGameController(DriveBaseController):
 class DriveControlWidget(QWidget):
     movementStarted = Signal()
     movementStopped = Signal()
+    targetPositionChanged = Signal(list)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -1371,6 +1372,9 @@ class DriveControlWidget(QWidget):
 
         self.desktop_controller_widget.zeroDrive.connect(self._zero_drive)
         self.desktop_controller_widget.moveTo.connect(self._move_to)
+        self.desktop_controller_widget.targetPositionChanged.connect(
+            self.targetPositionChanged.emit
+        )
 
         self.controller_combo_box.currentTextChanged.connect(self._switch_stack)
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -668,6 +668,7 @@ class DriveBaseController(QWidget):
     movementStopped = Signal()
     moveTo = Signal(list)
     zeroDrive = Signal()
+    targetPositionChanged = Signal(list)
 
     def __init__(self, axis_display_mode="interactive", parent=None):
         # axis_display_mode == "interactive" or "readonly"
@@ -743,6 +744,13 @@ class DriveBaseController(QWidget):
             return None
 
         return target_position
+
+    def _target_position_changed(self, position):
+        self.logger.info(f"DBC target position changed {self.target_position}")
+        tpos = self.target_position
+        if tpos is None:
+            tpos = []
+        self.targetPositionChanged.emit(tpos)
 
     def link_motion_group(self, mg: MotionGroup):
         if not isinstance(mg, MotionGroup):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1843,9 +1843,16 @@ class MGWidget(QWidget):
         self.drive_control_widget.targetPositionChanged.connect(
             self.mpl_canvas.update_target_position_plot
         )
+        self.drive_control_widget.driveStatusChanged.connect(
+            self._update_position_in_plot
+        )
 
         self.done_btn.clicked.connect(self.return_and_close)
         self.discard_btn.clicked.connect(self.close)
+
+    def _update_position_in_plot(self):
+        position = self.drive_control_widget.position
+        self.mpl_canvas.update_position_plot(position)
 
     def _define_layout(self):
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1437,6 +1437,10 @@ class DriveControlWidget(QWidget):
         return self._mg
 
     @property
+    def position(self) -> List[float]:
+        return self.desktop_controller_widget.position
+
+    @property
     def target_position(self):
         return self.desktop_controller_widget.target_position
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1421,6 +1421,10 @@ class DriveControlWidget(QWidget):
     def mg(self) -> Union[MotionGroup, None]:
         return self._mg
 
+    @property
+    def target_position(self):
+        return self.desktop_controller_widget.target_position
+
     def _stop_move(self):
         self.mg.stop()
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2457,6 +2457,9 @@ class MGWidget(QWidget):
 
         self.drive_control_widget.link_motion_group(self.mg)
 
+        target_position = self.drive_control_widget.target_position
+        self.drive_control_widget.targetPositionChanged.emit(target_position)
+
     def _update_drive_dropdown(self):
         if self._custom_drive_index == -1:
             # this should never happen if self._custom_drive_index was

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -236,11 +236,16 @@ class MotionSpaceDisplay(QFrame):
         self.mpl_canvas.draw()
 
     def update_target_position_plot(self, position):
-        self.logger.debug(f"Drawing target position {position}")
+        self.logger.info(f"Drawing target position {position}")
+
+        if isinstance(position, np.ndarray):
+            position = position.squeeze()
+            position = position.tolist()
 
         if not bool(position):
             position = None
 
+        # add target position dot
         _label = "target"
         stuff = self._get_plot_axis_by_name(_label)
         if stuff is not None:
@@ -251,7 +256,7 @@ class MotionSpaceDisplay(QFrame):
             else:
                 handler.set_offsets(position)
         elif position is None:
-            return
+            pass
         else:
             ax = self.mpl_canvas.figure.gca()
 

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -1,13 +1,9 @@
 __all__ = ["MotionSpaceDisplay"]
 
 import logging
+import numpy as np
 import warnings
 
-import matplotlib as mpl
-import numpy as np
-
-from matplotlib import pyplot as plt
-from matplotlib.collections import PathCollection
 from PySide6.QtCore import Signal
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QFrame, QSizePolicy, QVBoxLayout
@@ -18,7 +14,10 @@ from bapsf_motion.motion_builder import MotionBuilder
 
 # noqa
 # the matplotlib backend imports must happen after import matplotlib and PySide6
+import matplotlib as mpl
 mpl.use("qtagg")  # matplotlib's backend for Qt bindings
+from matplotlib import pyplot as plt
+from matplotlib.collections import PathCollection
 from matplotlib.backend_bases import Event, MouseEvent, PickEvent
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas  # noqa
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar  # noqa

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -78,6 +78,23 @@ class MotionSpaceDisplay(QFrame):
     def mb(self) -> Union[MotionBuilder, None]:
         return self._mb
 
+    def _get_plot_axis_by_name(self, name: str):
+        fig_axes = self.mpl_canvas.figure.axes
+        for ax in fig_axes:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                legend_handles, legend_labels = ax.get_legend_handles_labels()
+
+            if name not in legend_labels:
+                continue
+
+            index = legend_labels.index(name)
+            handler = legend_handles[index]
+
+            return ax, handler
+
+        return None
+
     def on_pick(self, event: PickEvent):
         gui_event = event.guiEvent  # type: QMouseEvent
 

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -1,0 +1,111 @@
+__all__ = ["MotionSpaceDisplay"]
+
+import logging
+import matplotlib as mpl
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import QFrame, QSizePolicy, QVBoxLayout
+from typing import Union
+
+from bapsf_motion.gui.configure.helpers import gui_logger
+from bapsf_motion.motion_builder import MotionBuilder
+
+# noqa
+# the matplotlib backend imports must happen after import matplotlib and PySide6
+mpl.use("qtagg")  # matplotlib's backend for Qt bindings
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas  # noqa
+
+
+class MotionSpaceDisplay(QFrame):
+    mbChanged = Signal()
+
+    def __init__(
+        self, mb: MotionBuilder = None, parent=None
+    ):
+        super().__init__(parent=parent)
+
+        self._logger = logging.getLogger(f"{gui_logger.name}.MSD")
+
+        self._mb = None
+        self.link_motion_builder(mb)
+
+        self.setStyleSheet(
+            """
+            MotionSpaceDisplay {
+                border: 2px solid rgb(125, 125, 125);
+                border-radius: 5px; 
+                padding: 0px;
+                margin: 0px;
+            }
+            """
+        )
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        self.mpl_canvas = FigureCanvas()
+        self.mpl_canvas.setParent(self)
+
+        self.setLayout(self._define_layout())
+        self._connect_signals()
+
+    def _connect_signals(self):
+        self.mbChanged.connect(self.update_canvas)
+
+    def _define_layout(self):
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.mpl_canvas)
+
+        return layout
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    @property
+    def mb(self) -> Union[MotionBuilder, None]:
+        return self._mb
+
+    def link_motion_builder(self, mb: MotionBuilder):
+        if not isinstance(mb, MotionBuilder):
+            self.unlink_motion_builder()
+            return
+
+        self._mb = mb
+        self.setHidden(False)
+
+    def unlink_motion_builder(self):
+        self._mb = None
+        self.setHidden(True)
+
+    def update_canvas(self):
+        if not isinstance(self.mb, MotionBuilder):
+            self.setHidden(True)
+            return
+
+        if self.isHidden():
+            self.setHidden(False)
+
+        self.logger.info("Redrawing plot...")
+        self.logger.info(f"MB config = {self.mb.config}")
+
+        self.mpl_canvas.figure.clear()
+        ax = self.mpl_canvas.figure.gca()
+        xdim, ydim = self.mb.mspace_dims
+        self.mb.mask.plot(x=xdim, y=ydim, ax=ax)
+
+        pts = self.mb.motion_list
+        if pts is not None:
+            ax.scatter(
+                x=pts[..., 0],
+                y=pts[..., 1],
+                linewidth=1,
+                s=2 ** 2,
+                facecolors="deepskyblue",
+                edgecolors="black",
+            )
+
+        self.mpl_canvas.draw()
+
+    def closeEvent(self, event):
+        self.logger.info(f"Closing {self.__class__.__name__}")
+        super().closeEvent(event)

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -182,7 +182,7 @@ class MotionSpaceDisplay(QFrame):
         ax = fig.gca()
 
         xdim, ydim = self.mb.mspace_dims
-        self.mb.mask.plot(x=xdim, y=ydim, ax=ax, label="mask")
+        self.mb.mask.plot(x=xdim, y=ydim, ax=ax, add_colorbar=False, label="mask")
 
         # Draw motion list
         pts = self.mb.motion_list

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -142,7 +142,7 @@ class MotionSpaceDisplay(QFrame):
         self.mpl_canvas.figure.clear()
         ax = self.mpl_canvas.figure.gca()
         xdim, ydim = self.mb.mspace_dims
-        self.mb.mask.plot(x=xdim, y=ydim, ax=ax)
+        self.mb.mask.plot(x=xdim, y=ydim, ax=ax, label="mask")
 
         pts = self.mb.motion_list
         if pts is not None:
@@ -154,6 +154,7 @@ class MotionSpaceDisplay(QFrame):
                 facecolors="deepskyblue",
                 edgecolors="black",
                 picker=True,
+                label="motion_list",
             )
 
         self.mpl_canvas.draw()

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -226,16 +226,22 @@ class MotionSpaceDisplay(QFrame):
         self.mpl_canvas.draw()
 
     def update_target_position_plot(self, position):
-        if position is None:
-            return
-
         self.logger.debug(f"Drawing target position {position}")
+
+        if not bool(position):
+            position = None
 
         _label = "target"
         stuff = self._get_plot_axis_by_name(_label)
         if stuff is not None:
             ax, handler = stuff  # type: plt.Axes, PathCollection
-            handler.set_offsets(position)
+
+            if position is None:
+                handler.remove()
+            else:
+                handler.set_offsets(position)
+        elif position is None:
+            return
         else:
             ax = self.mpl_canvas.figure.gca()
 

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -14,6 +14,7 @@ from bapsf_motion.motion_builder import MotionBuilder
 # the matplotlib backend imports must happen after import matplotlib and PySide6
 mpl.use("qtagg")  # matplotlib's backend for Qt bindings
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas  # noqa
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar  # noqa
 
 
 class MotionSpaceDisplay(QFrame):
@@ -44,6 +45,8 @@ class MotionSpaceDisplay(QFrame):
         self.mpl_canvas = FigureCanvas()
         self.mpl_canvas.setParent(self)
 
+        self.mpl_toolbar = NavigationToolbar(self.mpl_canvas, parent=self)
+
         self.setLayout(self._define_layout())
         self._connect_signals()
 
@@ -53,6 +56,7 @@ class MotionSpaceDisplay(QFrame):
     def _define_layout(self):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.mpl_toolbar)
         layout.addWidget(self.mpl_canvas)
 
         return layout

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -108,17 +108,25 @@ class MotionSpaceDisplay(QFrame):
         self.logger.info(f"target position = {target_position}")
         self.targetPositionSelected.emit(target_position)
 
-    def link_motion_builder(self, mb: MotionBuilder):
+    def link_motion_builder(self, mb: Union[MotionBuilder, None]):
+        self.logger.info(f"Linking Motion Builder {mb}")
+
+        self.blockSignals(True)
+        self.unlink_motion_builder()
+        self.blockSignals(False)
+
         if not isinstance(mb, MotionBuilder):
-            self.unlink_motion_builder()
+            self.mbChanged.emit()
             return
 
         self._mb = mb
         self.setHidden(False)
+        self.mbChanged.emit()
 
     def unlink_motion_builder(self):
         self._mb = None
         self.setHidden(True)
+        self.mbChanged.emit()
 
     def update_canvas(self):
         if not isinstance(self.mb, MotionBuilder):

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -204,6 +204,32 @@ class MotionSpaceDisplay(QFrame):
 
         self.mpl_canvas.draw()
 
+    def update_target_position_plot(self, position):
+        if position is None:
+            return
+
+        self.logger.debug(f"Drawing target position {position}")
+
+        _label = "target"
+        stuff = self._get_plot_axis_by_name(_label)
+        if stuff is not None:
+            ax, handler = stuff  # type: plt.Axes, PathCollection
+            handler.set_offsets(position)
+        else:
+            ax = self.mpl_canvas.figure.gca()
+
+            ax.scatter(
+                x=position[0],
+                y=position[1],
+                s=7 ** 2,
+                linewidth=2,
+                facecolors="none",
+                edgecolors="blue",
+                label=_label,
+            )
+
+        self.mpl_canvas.draw()
+
     def closeEvent(self, event):
         self.logger.info(f"Closing {self.__class__.__name__}")
         super().closeEvent(event)

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -64,6 +64,7 @@ class MotionSpaceDisplay(QFrame):
         self._mpl_pick_callback_id = self.mpl_canvas.mpl_connect(
             "pick_event", self.on_pick  # noqa
         )
+        self.targetPositionSelected.connect(self.update_target_position_plot)
 
     def _define_layout(self):
         layout = QVBoxLayout()

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -157,6 +157,34 @@ class MotionSpaceDisplay(QFrame):
                 label="motion_list",
             )
 
+        insertion_point = self.mb.get_insertion_point()
+        if insertion_point is not None:
+            ax.scatter(
+                x=insertion_point[0],
+                y=insertion_point[1],
+                s=3 ** 2,
+                linewidth=2,
+                facecolors="none",
+                edgecolors="red",
+                label="insertion_point",
+            )
+
+            # reset x range of plot
+            xlim = ax.get_xlim()
+            if insertion_point[0] > xlim[1]:
+                xlim = [xlim[0], 1.05 * insertion_point[0]]
+            elif insertion_point[0] < xlim[0]:
+                xlim = [1.05 * insertion_point[0], xlim[1]]
+            ax.set_xlim(xlim)
+
+            # reset y range of plot
+            ylim = ax.get_ylim()
+            if insertion_point[1] > ylim[1]:
+                ylim = [ylim[0], 1.05 * insertion_point[1]]
+            elif insertion_point[1] < ylim[0]:
+                ylim = [1.05 * insertion_point[1], ylim[1]]
+            ax.set_ylim(ylim)
+
         self.mpl_canvas.draw()
 
     def closeEvent(self, event):

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -150,7 +150,7 @@ class MotionSpaceDisplay(QFrame):
                 x=pts[..., 0],
                 y=pts[..., 1],
                 linewidth=1,
-                s=2 ** 2,
+                s=3 ** 2,
                 facecolors="deepskyblue",
                 edgecolors="black",
                 picker=True,

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -184,6 +184,8 @@ class MotionSpaceDisplay(QFrame):
         xdim, ydim = self.mb.mspace_dims
         self.mb.mask.plot(x=xdim, y=ydim, ax=ax, add_colorbar=False, label="mask")
 
+        fig.tight_layout()
+
         # Draw motion list
         pts = self.mb.motion_list
         if pts is not None:

--- a/bapsf_motion/motion_builder/core.py
+++ b/bapsf_motion/motion_builder/core.py
@@ -415,6 +415,24 @@ class MotionBuilder(MBItem):
             dims=("index", "space")
         )
 
+    def get_insertion_point(self) -> Union[np.ndarray, None]:
+        """
+        Get the insertion point associated with the `GovernExclusion.
+        Returns `None` if no insertion point exists.
+        """
+        try:
+            ex = self.exclusions[0]
+        except IndexError:
+            return None
+
+        if not isinstance(ex, GovernExclusion):
+            return None
+
+        if not hasattr(ex, "insertion_point"):
+            return None
+
+        return ex.insertion_point  # noqa
+
     def clear_motion_list(self):
         """
         Clear/delete the currently constructed :term:`motion list`.


### PR DESCRIPTION
This PR does:

- Creates module `bapsf_motion.gui.configure.motion_space_display`.  This module contains plotter functionality to display the motion space defined by a `MotionBuilder` instance.
- Extracts the plotting functionality from `MotionBuilderConfigOverlay` and creates the `MotionSpaceDisplay` class (in the above mentioned module).
- The `MotionSpaceDisplay` class is a `QWidget` that will plot the motion space associated with a `MotionBuilder` instance.  This class is used in both the `MotionBuilderConfigOverlay` during the motion builder configuration, and the `MGWidget` during motion group configuration and control.
- The main plotting of `MotionSpaceDisplay` is done using the `qtagg` backend of `matplotlib`.
- The plotted display also exposes the `matplotlib` controls so users can zoom in and pan displays.
- Several interfaces are designed into `MotionSpaceDisplay` so...
    - A user can select a new target position for the probe by clicking on one of the displayed motion list points.
    - If a probe position is given and the motion space has a defined insertion point, then the probe shaft will be plotted.  If the insertion point does not exist then only the position point is plotted.
    - Signals are setup so the display is updated in real-time as the probe moves.
    - Signals are setup so the controller widgets are updated when a new target position is selected.