### PR TITLE
Patch Restarting of `rm` when returning from a motion group configuration

### DIFF
--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -358,7 +358,7 @@ class ConfigureGUI(QMainWindow):
         return self._logging_config_dict
 
     def replace_rm(self, config):
-        if isinstance(self.rm, RunManager) and not self.rm.terminated:
+        if isinstance(self.rm, RunManager):
             self.rm.terminate()
 
         self.logger.info(f"Replacing the run manager with new config: {config}.")


### PR DESCRIPTION
When returning from a motion group configuration `MGWidget` session, ensure `RunWidget` fully terminates `rm` before restarting it.  This is to ensure we do not end up with multiple `rm` actors trying to interact with the motors.