### PR TITLE
Collection of patch post release of `v0.2.3`

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2887,14 +2887,7 @@ class MGWidget(QWidget):
         self.transform_btn.setEnabled(False)
 
     def enable_config_controls(self):
-        self.drive_dropdown.setEnabled(True)
-        self.drive_btn.setEnabled(True)
-
-        self.mb_dropdown.setEnabled(True)
-        self.mb_btn.setEnabled(True)
-
-        self.transform_dropdown.setEnabled(True)
-        self.transform_btn.setEnabled(True)
+        self._validate_motion_group()
 
     def return_and_close(self):
         config = _deepcopy_dict(self.mg.config)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -50,6 +50,7 @@ from bapsf_motion.gui.widgets import (
     HLinePlain,
     IconButton,
     LED,
+    QTAIconLabel,
     StyleButton,
     StopButton,
     ValidButton,
@@ -1685,11 +1686,9 @@ class MGWidget(QWidget):
         _btn = DiscardButton(parent=self)
         self.discard_btn = _btn
 
-        _icon = QLabel(parent=self)
-        _icon.setPixmap(qta.icon("mdi.steering").pixmap(24, 24))
-        _icon.setMaximumWidth(32)
-        _icon.setMaximumHeight(32)
-        _icon.setAlignment(Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter)
+        _icon = QTAIconLabel("mdi.steering", parent=self)
+        _icon.setFixedSize(32)
+        _icon.setIconSize(24)
         self.drive_label = _icon
 
         _w = QComboBox(parent=self)
@@ -1706,11 +1705,10 @@ class MGWidget(QWidget):
         _btn = GearValidButton(parent=self)
         self.drive_btn = _btn
 
-        _icon = QLabel(parent=self)
-        _icon.setPixmap(qta.icon("mdi.motion").pixmap(24, 24))
-        _icon.setMaximumWidth(32)
-        _icon.setMaximumHeight(32)
         _icon.setAlignment(Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter)
+        _icon = QTAIconLabel("mdi.motion", parent=self)
+        _icon.setFixedSize(32)
+        _icon.setIconSize(24)
         self.mb_label = _icon
 
         _w = QComboBox(parent=self)
@@ -1728,11 +1726,9 @@ class MGWidget(QWidget):
         _btn.setEnabled(False)
         self.mb_btn = _btn
 
-        _icon = QLabel(parent=self)
-        _icon.setPixmap(qta.icon("fa5s.exchange-alt").pixmap(24, 24))
-        _icon.setMaximumWidth(32)
-        _icon.setMaximumHeight(32)
-        _icon.setAlignment(Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter)
+        _icon = QTAIconLabel("fa5s.exchange-alt", parent=self)
+        _icon.setFixedSize(32)
+        _icon.setIconSize(24)
         self.transform_label = _icon
 
         _w = QComboBox(parent=self)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1888,10 +1888,11 @@ class MGWidget(QWidget):
 
     def _define_mg_builder_layout(self):
         layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addLayout(self._define_toml_layout())
-        layout.addSpacing(12)
+        layout.addSpacing(8)
         layout.addWidget(self._define_central_builder_widget())
-        layout.addSpacing(12)
+        layout.addSpacing(8)
         layout.addWidget(self.mpl_canvas)
 
         return layout
@@ -1913,10 +1914,7 @@ class MGWidget(QWidget):
 
     def _define_central_builder_widget(self):
 
-        _label = QLabel("Name:  ", parent=self)
-        _label.setAlignment(
-            Qt.AlignmentFlag.AlignVCenter | Qt. AlignmentFlag.AlignLeft
-        )
+        _label = QLabel("Name:", parent=self)
         _label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         font = _label.font()
         font.setPointSize(16)
@@ -1924,7 +1922,9 @@ class MGWidget(QWidget):
         name_label = _label
 
         title_sub_layout = QHBoxLayout()
+        title_sub_layout.setContentsMargins(12, 0, 12, 0)
         title_sub_layout.addWidget(name_label)
+        title_sub_layout.addSpacing(4)
         title_sub_layout.addWidget(self.mg_name_widget)
 
         drive_sub_layout = QHBoxLayout()
@@ -1943,9 +1943,10 @@ class MGWidget(QWidget):
         transform_sub_layout.addWidget(self.transform_btn)
 
         layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addSpacing(18)
         layout.addLayout(title_sub_layout)
-        layout.addSpacing(18)
+        layout.addSpacing(12)
         layout.addLayout(drive_sub_layout)
         layout.addLayout(mb_sub_layout)
         layout.addLayout(transform_sub_layout)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2791,11 +2791,14 @@ class MGWidget(QWidget):
 
         if not isinstance(transform, BaseTransform):
             self.transform_btn.set_invalid()
-            self.done_btn.setEnabled(False)
+            self.transform_btn.setToolTip("Transformer needs to be fully configured.")
 
+            self.done_btn.setEnabled(False)
             self.drive_control_widget.setEnabled(False)
         else:
             self.transform_btn.set_valid()
+            self.transform_btn.setToolTip("")
+
             self.drive_control_widget.setEnabled(True)
 
         if (

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1859,7 +1859,10 @@ class MGWidget(QWidget):
         self.discard_btn.clicked.connect(self.close)
 
     def _update_position_in_plot(self):
-        position = self.drive_control_widget.position
+        if self.drive_control_widget.isEnabled():
+            position = self.drive_control_widget.position
+        else:
+            position = None
         self.mpl_canvas.update_position_plot(position)
 
     def _define_layout(self):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2768,6 +2768,14 @@ class MGWidget(QWidget):
         vmg_name = self._validate_motion_group_name()
         vdrive = self._validate_drive()
 
+        # Enable / Disable Motion Builder Config
+        self.mb_dropdown.setEnabled(vdrive)
+        self.mb_btn.setEnabled(vdrive)
+
+        # Enable / Disable Transformer Config
+        self.transform_dropdown.setEnabled(vdrive)
+        self.transform_btn.setEnabled(vdrive)
+
         if not isinstance(self.mg, MotionGroup):
             mb = None
             transform = None
@@ -2779,15 +2787,14 @@ class MGWidget(QWidget):
             self.mb_btn.set_invalid()
             self.mb_btn.setToolTip("Motion space needs to be defined.")
             self.done_btn.setEnabled(False)
+        elif "layer" not in mb.config:
+            self.mb_btn.set_invalid()
+            self.mb_btn.setToolTip(
+                "A point layer needs to be defined to generate a motion list."
+            )
         else:
-            if "layer" not in mb.config:
-                self.mb_btn.set_invalid()
-                self.mb_btn.setToolTip(
-                    "A point layer needs to be defined to generate a motion list."
-                )
-            else:
-                self.mb_btn.set_valid()
-                self.mb_btn.setToolTip("")
+            self.mb_btn.set_valid()
+            self.mb_btn.setToolTip("")
 
         if not isinstance(transform, BaseTransform):
             self.transform_btn.set_invalid()

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1390,6 +1390,12 @@ class DriveControlWidget(QWidget):
         self.desktop_controller_widget.driveStatusChanged.connect(
             self.driveStatusChanged.emit
         )
+        self.desktop_controller_widget.movementStarted.connect(
+            self._drive_movement_started
+        )
+        self.desktop_controller_widget.movementStopped.connect(
+            self._drive_movement_finished
+        )
 
         self.controller_combo_box.currentTextChanged.connect(self._switch_stack)
 
@@ -1530,19 +1536,13 @@ class DriveControlWidget(QWidget):
         if self.game_controller_widget is not None:
             self.game_controller_widget.update_all_axis_displays()
 
-    @Slot(int)
-    def _drive_movement_started(self, axis_index):
+    def _drive_movement_started(self):
+        self.controller_combo_box.setEnabled(False)
         self.movementStarted.emit()
 
-    @Slot(int)
-    def _drive_movement_finished(self, axis_index):
-        if not isinstance(self.mg, MotionGroup) or not isinstance(self.mg.drive, Drive):
-            return
-
-        is_moving = [ax.is_moving for ax in self.mg.drive.axes]
-        is_moving[axis_index] = False
-        if not any(is_moving):
-            self.movementStopped.emit()
+    def _drive_movement_finished(self):
+        self.controller_combo_box.setEnabled(True)
+        self.movementStopped.emit()
 
     @Slot(list)
     def _move_to(self, target_pos):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1758,6 +1758,9 @@ class MGWidget(QWidget):
         self.drive_control_widget.setEnabled(False)
 
         self.mpl_canvas = MotionSpaceDisplay(parent=self)
+        _policy = self.mpl_canvas.sizePolicy()
+        _policy.setRetainSizeWhenHidden(True)
+        self.mpl_canvas.setSizePolicy(_policy)
 
         self.setLayout(self._define_layout())
         self._connect_signals()

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1882,7 +1882,7 @@ class MGWidget(QWidget):
         layout = QHBoxLayout()
         layout.addLayout(self._define_toml_layout())
         layout.addSpacing(12)
-        layout.addLayout(self._define_central_builder_layout())
+        layout.addWidget(self._define_central_builder_widget())
         layout.addSpacing(12)
         layout.addWidget(self.mpl_canvas)
 
@@ -1903,7 +1903,7 @@ class MGWidget(QWidget):
 
         return layout
 
-    def _define_central_builder_layout(self):
+    def _define_central_builder_widget(self):
 
         _label = QLabel("Name:  ", parent=self)
         _label.setAlignment(
@@ -1943,7 +1943,9 @@ class MGWidget(QWidget):
         layout.addLayout(transform_sub_layout)
         layout.addStretch()
 
-        return layout
+        _widget = QWidget(parent=self)
+        _widget.setLayout(layout)
+        return _widget
 
     def _build_drive_defaults(self) -> List[Tuple[str, Dict[str, Any]]]:
         # Returned _drive_defaults is a List of Tuple pairs

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -565,6 +565,9 @@ class AxisControlWidget(QWidget):
         if self._mg.terminated:
             return
 
+        if not self.isEnabled():
+            return
+
         pos = self.position
         self.position_label.setText(f"{pos.value:.2f} {pos.unit}")
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2773,6 +2773,9 @@ class MGWidget(QWidget):
             self.drive_btn.setToolTip("Drive is not fully configured.")
             return False
 
+        self.drive_dropdown.setEnabled(True)
+        self.drive_btn.setEnabled(True)
+
         self.mb_dropdown.setEnabled(True)
         self.mb_btn.setEnabled(True)
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1945,6 +1945,7 @@ class MGWidget(QWidget):
 
         _widget = QWidget(parent=self)
         _widget.setLayout(layout)
+        _widget.setFixedWidth(335)
         return _widget
 
     def _build_drive_defaults(self) -> List[Tuple[str, Dict[str, Any]]]:

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1945,9 +1945,6 @@ class MGWidget(QWidget):
 
         return layout
 
-    def _define_mspace_display_layout(self):
-        ...
-
     def _build_drive_defaults(self) -> List[Tuple[str, Dict[str, Any]]]:
         # Returned _drive_defaults is a List of Tuple pairs
         # - 1st Tuple element is the dropdown name

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1942,6 +1942,72 @@ class MGWidget(QWidget):
         transform_sub_layout.addWidget(self.transform_dropdown)
         transform_sub_layout.addWidget(self.transform_btn)
 
+        _legend_txt = QLabel("LEGEND", parent=self)
+        font = _legend_txt.font()
+        font.setBold(True)
+        font.setPointSize(10)
+        _legend_txt.setFont(font)
+
+        valid_gear_legend_layout = QHBoxLayout()
+        valid_gear_legend_layout.setContentsMargins(0, 0, 0, 0)
+        _btn = GearValidButton(parent=self)
+        _btn.set_valid()
+        _btn.setFixedSize(24)
+        _btn.setIconSize(20)
+        valid_gear_legend_layout.addWidget(_btn)
+        valid_gear_legend_layout.addSpacing(4)
+        valid_gear_legend_layout.addWidget(
+            QLabel("Configuration valid. Click to edit.", parent=self)
+        )
+
+        invalid_gear_legend_layout = QHBoxLayout()
+        invalid_gear_legend_layout.setContentsMargins(0, 0, 0, 0)
+        _btn = GearValidButton(parent=self)
+        _btn.set_invalid()
+        _btn.setFixedSize(24)
+        _btn.setIconSize(20)
+        invalid_gear_legend_layout.addWidget(_btn)
+        invalid_gear_legend_layout.addSpacing(4)
+        invalid_gear_legend_layout.addWidget(
+            QLabel(
+                "Configuration invalid. Click to edit.\nHover for tooltip.",
+                parent=self,
+            ),
+        )
+
+        drive_legend_layout = QHBoxLayout()
+        drive_legend_layout.setContentsMargins(2, 0, 0, 0)
+        _icon = QTAIconLabel("mdi.steering", parent=self)
+        _icon.setFixedSize(20)
+        _icon.setIconSize(20)
+        drive_legend_layout.addWidget(_icon)
+        drive_legend_layout.addSpacing(6)
+        drive_legend_layout.addWidget(
+            QLabel("Drive configuration.", parent=self)
+        )
+
+        mb_legend_layout = QHBoxLayout()
+        mb_legend_layout.setContentsMargins(2, 0, 0, 0)
+        _icon = QTAIconLabel("mdi.motion", parent=self)
+        _icon.setFixedSize(20)
+        _icon.setIconSize(20)
+        mb_legend_layout.addWidget(_icon)
+        mb_legend_layout.addSpacing(6)
+        mb_legend_layout.addWidget(
+            QLabel("Motion Builder / Space configuration.", parent=self)
+        )
+
+        tr_legend_layout = QHBoxLayout()
+        tr_legend_layout.setContentsMargins(2, 0, 0, 0)
+        _icon = QTAIconLabel("fa5s.exchange-alt", parent=self)
+        _icon.setFixedSize(20)
+        _icon.setIconSize(20)
+        tr_legend_layout.addWidget(_icon)
+        tr_legend_layout.addSpacing(6)
+        tr_legend_layout.addWidget(
+            QLabel("Transformer configuration.", parent=self)
+        )
+
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addSpacing(18)
@@ -1950,6 +2016,18 @@ class MGWidget(QWidget):
         layout.addLayout(drive_sub_layout)
         layout.addLayout(mb_sub_layout)
         layout.addLayout(transform_sub_layout)
+        layout.addSpacing(8)
+        layout.addWidget(HLinePlain(parent=self))
+        layout.addWidget(
+            _legend_txt,
+            alignment=Qt.AlignmentFlag.AlignCenter,
+        )
+        layout.addLayout(valid_gear_legend_layout)
+        layout.addLayout(invalid_gear_legend_layout)
+        layout.addSpacing(4)
+        layout.addLayout(drive_legend_layout)
+        layout.addLayout(mb_legend_layout)
+        layout.addLayout(tr_legend_layout)
         layout.addStretch()
 
         _widget = QWidget(parent=self)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2848,15 +2848,6 @@ class MGWidget(QWidget):
         if not isinstance(self.mg, MotionGroup) or not isinstance(self.mg.drive, Drive):
             self.done_btn.setEnabled(False)
 
-            self.mb_dropdown.setEnabled(False)
-            self.mb_btn.setEnabled(False)
-            self.mb_btn.set_invalid()
-            self.mb_btn.setToolTip("Motion space needs to be defined.")
-
-            self.transform_dropdown.setEnabled(False)
-            self.transform_btn.setEnabled(False)
-            self.transform_btn.set_invalid()
-
             self.drive_btn.set_invalid()
             self.drive_control_widget.setEnabled(False)
 
@@ -2865,12 +2856,6 @@ class MGWidget(QWidget):
 
         self.drive_dropdown.setEnabled(True)
         self.drive_btn.setEnabled(True)
-
-        self.mb_dropdown.setEnabled(True)
-        self.mb_btn.setEnabled(True)
-
-        self.transform_dropdown.setEnabled(True)
-        self.transform_btn.setEnabled(True)
 
         if self.mg.drive.terminated:
             self.drive_btn.set_invalid()

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -234,6 +234,31 @@ class MotionSpaceDisplay(QFrame):
         # Draw current position
         self.update_position_plot(position=position)
 
+        # Draw legend
+        self.update_legend()
+
+        self.mpl_canvas.draw()
+
+    def update_legend(self):
+        _names = ["motion_list", "probe", "position", "target", "insertion_point"]
+
+        # gather handles for legend
+        handles = []
+        for name in _names:
+            stuff = self._get_plot_axis_by_name(name)
+            if stuff is None:
+                continue
+
+            ax, handle = stuff
+            handles.append(handle)
+
+        if len(handles) == 0:
+            self.mpl_canvas.draw()
+            return
+
+        ax = self.mpl_canvas.figure.gca()
+        ax.legend(handles=handles)
+
         self.mpl_canvas.draw()
 
     def update_target_position_plot(self, position):
@@ -271,6 +296,7 @@ class MotionSpaceDisplay(QFrame):
                 label=_label,
             )
 
+        self.update_legend()
         self.mpl_canvas.draw()
 
     def update_position_plot(self, position):
@@ -343,6 +369,7 @@ class MotionSpaceDisplay(QFrame):
                 label=_label,
             )
 
+        self.update_legend()
         self.mpl_canvas.draw()
 
     def closeEvent(self, event):

--- a/bapsf_motion/gui/widgets/__init__.py
+++ b/bapsf_motion/gui/widgets/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "QLineEditSpecialized",
     "QLogger",
     "QLogHandler",
+    "QTAIconLabel",
     "StopButton",
     "StyleButton",
     "ValidButton",
@@ -41,6 +42,7 @@ from bapsf_motion.gui.widgets.misc import (
     BatteryStatusIcon,
     IPv4Validator,
     QLineEditSpecialized,
+    QTAIconLabel,
     HLinePlain,
     VLinePlain,
 )

--- a/bapsf_motion/gui/widgets/buttons.py
+++ b/bapsf_motion/gui/widgets/buttons.py
@@ -399,13 +399,14 @@ class GearValidButton(ValidButton):
             action="checked",
         )  # checked state is the valid state
 
-        self._size = 32
-        self._icon_size = 28
-
-        self.setFixedWidth(self._size)
-        self.setFixedHeight(self._size)
         self.setIcon(self._invalid_icon)
-        self.setIconSize(QSize(self._icon_size, self._icon_size))
+
+        self._size = None
+        self.setFixedSize(32)
+
+        self._icon_size = None
+        self.setIconSize(28)
+
         self.setChecked(False)
 
     def set_valid(self, state: bool = True):
@@ -416,6 +417,32 @@ class GearValidButton(ValidButton):
     def set_invalid(self):
         self.setIcon(self._invalid_icon)
         super().set_invalid()
+
+    def setIconSize(self, size: int):
+        if not isinstance(size, int):
+            return
+        elif size <= 0:
+            return
+
+        self._icon_size = size
+        size = QSize(size, size)
+        super().setIconSize(size)
+
+    def setFixedSize(self, size: int):
+        if not isinstance(size, int):
+            return
+        elif size <= 0:
+            return
+
+        self._size = size
+        size = QSize(size, size)
+        super().setFixedSize(size)
+
+    def setFixedHeight(self, h):
+        self.setFixedSize(h)
+
+    def setFixedWidth(self, w):
+        self.setFixedSize(w)
 
     def _change_validation_icon(self):
         _icon = self._valid_icon if self.is_valid else self._invalid_icon

--- a/bapsf_motion/gui/widgets/misc.py
+++ b/bapsf_motion/gui/widgets/misc.py
@@ -3,21 +3,82 @@ __all__ = [
     "BatteryStatusIcon",
     "IPv4Validator",
     "QLineEditSpecialized",
+    "QTAIconLabel",
     "HLinePlain",
     "VLinePlain",
 ]
 
 import logging
 
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QValidator, QColor
+from PySide6.QtCore import Qt, Signal, QSize
+from PySide6.QtGui import QValidator, QColor, QIcon
 from PySide6.QtWidgets import QFrame, QLabel, QLineEdit, QWidget
+from typing import Union
 
 # noqa
 # import of qtawesome must happen after the PySide6 imports
 import qtawesome as qta
 
 from bapsf_motion.utils import ipv4_pattern as _ipv4_pattern
+
+
+class QTAIconLabel(QLabel):
+    def __init__(self, icon_name, parent=None):
+        super().__init__(parent=parent)
+
+        self._icon_name = None
+        self._icon = None
+        self.setIcon(icon_name)
+
+        self.setFixedSize(32)
+        self.setIconSize(28)
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter)
+
+    @property
+    def icon_name(self) -> str:
+        return self._icon_name
+
+    @property
+    def icon(self) -> QIcon:
+        return self._icon
+
+    def _get_icon(self):
+        return qta.icon(self._icon_name)
+
+    def setIcon(self, icon_name: str):  # noqa
+        try:
+            _icon = qta.icon(icon_name)
+        except Exception:  # noqa
+            return
+
+        self._icon_name = icon_name
+        self._icon = _icon
+
+    def setIconSize(self, size: int):  # noqa
+        if not isinstance(size, int):
+            return
+        elif size < 1:
+            return
+
+        self.setPixmap(self.icon.pixmap(size, size))
+
+    def setFixedSize(self, size: Union[QSize, int]):
+        if isinstance(size, QSize):
+            pass
+        elif not isinstance(size, int):
+            return
+        elif size < 1:
+            return
+        else:
+            size = QSize(size, size)
+
+        super().setFixedSize(size)
+
+    def setFixedWidth(self, w):
+        self.setFixedSize(w)
+
+    def setFixedHeight(self, h):
+        self.setFixedSize(h)
 
 
 class BatteryStatusIcon(QLabel):


### PR DESCRIPTION
This is an assorted collection of patches pose release of `v0.2.3`

- Reconnect the `movementStarted` and `movementFinished` signals between `DriveControlWidget` and `DriveDesktopController` so the motion group configuration widgets are properly disabled during the movement.
- Disable the control mode selection box during drive movement.
- Give the central motion group config widgets a fixed with so they do NOT stretch during a resize.
- Have the the plot in `MGWidget` retain its size when hidden (prevents stretching of other widgets).
- Have `AxisControlWidget.target_position` return `None` if the text box contains an empty string.  This prevents a `ValueError` from being raised before the widget is fully initialized.
- Update `GearValidButton` to allow for more external control of setting icon and fixed sizes.
- Created `QTAIconLabel` class to streamline placing icons from `qtawesome`.
- If the transformer is changed from a valid one to and invalid transform, stop updating displays that require pinging the motor for position.  If you do not do this, then a `ValueError` will be raised since there is no transform to convert between the drive coordinates and motion space coordinates.
- Add a simple legend to the `MGWidget` central builder layout.
- Add a legend to the display generated by `MotionSpaceDisplay`.