### PR TITLE
Update docs and fix some exiting warnings

### DIFF
--- a/bapsf_motion/gui/configure/__init__.py
+++ b/bapsf_motion/gui/configure/__init__.py
@@ -1,3 +1,6 @@
+"""
+Module containing all the elements for the Configuration GUI.
+"""
 __all__ = ["ConfigureGUI"]
 from bapsf_motion.gui.configure.configure_ import ConfigureGUI
 

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -1,3 +1,7 @@
+"""
+Module contains base classes for various
+`~PySide6.QtWidgets.QWidget`\'s used in the Configuration GUI.
+"""
 __all__ = ["_ConfigOverlay", "_OverlayWidget",]
 
 import logging

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -1,5 +1,8 @@
 """
 This module defines the configuration GUI for construction data runs.
+Module contains both the `~PySide6.QtWidgets.QMainWindow` in
+`ConfigureGUI` and the `~PySide6.QtWidgets.QApplication` in
+`ConfigureApp`.
 """
 __all__ = ["ConfigureGUI", "ConfigureApp"]
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -1,3 +1,8 @@
+"""
+Module contains the functionality associated with the |Drive|
+configuration overlay portion of the configuration GUI.
+"""
+
 __all__ = ["AxisConfigWidget", "DriveConfigOverlay"]
 
 import asyncio

--- a/bapsf_motion/gui/configure/helpers.py
+++ b/bapsf_motion/gui/configure/helpers.py
@@ -1,3 +1,6 @@
+"""
+Module of helper functions for the Configuration GUI.
+"""
 __all__ = ["gui_logger", "gui_logger_config_dict"]
 
 import logging

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1,3 +1,7 @@
+"""
+Module contains the functionality associated with the |MotionBuilder|
+configuration overlay portion of the configuration GUI.
+"""
 __all__ = ["MotionBuilderConfigOverlay"]
 
 import ast

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1,3 +1,7 @@
+"""
+Module contains all the main functionality for the |MotionGroup|
+configuration portion of the configuration GUI.
+"""
 __all__ = ["MGWidget"]
 
 import asyncio

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -1,3 +1,8 @@
+"""
+Module contains the `~PySide6.QtWidgets.QWidget` used for displaying /
+plotting the :term:`motion space` associated with a |MotionBuilder|
+instance.
+"""
 __all__ = ["MotionSpaceDisplay"]
 
 import logging

--- a/bapsf_motion/gui/configure/transform_overlay.py
+++ b/bapsf_motion/gui/configure/transform_overlay.py
@@ -1,3 +1,8 @@
+"""
+Module contains the functionality associated with the
+:term:`transformer` configuration overlay portion of the configuration
+GUI.
+"""
 __all__ = ["TransformConfigOverlay"]
 
 import ast

--- a/bapsf_motion/gui/helpers.py
+++ b/bapsf_motion/gui/helpers.py
@@ -16,7 +16,7 @@ def get_qapplication() -> Union[QApplication, None]:
     """
     Get the current active instance of
     `~PySide6.QtWidgets.QApplication`.  This is a convinces function
-    to :func:`~PySide6.QtCore.QCoreApplication.instance`.
+    to `~PySide6.QtCore.QCoreApplication.instance`.
     """
     app = QApplication.instance()
     return app

--- a/bapsf_motion/gui/helpers.py
+++ b/bapsf_motion/gui/helpers.py
@@ -13,17 +13,38 @@ from typing import Union
 
 
 def get_qapplication() -> Union[QApplication, None]:
+    """
+    Get the current active instance of
+    `~PySide6.QtWidgets.QApplication`.  This is a convinces function
+    to :func:`~PySide6.QtCore.QCoreApplication.instance`.
+    """
     app = QApplication.instance()
     return app
 
 
 def get_color_scheme() -> "Qt.ColorScheme":
+    """
+    Retrieve the color scheme (light or dark mode) of the operating
+    system.  The returns the `~PySide6.QtCore.Qt.ColorScheme` `enum`.
+    """
     app = get_qapplication()
     _scheme = app.styleHints().colorScheme()
     return _scheme
 
 
 def cast_color_to_rgba_string(color: Union[QColor, str]) -> str:
+    """
+    Cast ``color`` to an RGBA string representation
+    ``'rgba(r, g, b, a)'``
+
+    Parameters
+    ----------
+    color : Union[QColor, str]
+        ``color`` can be an instance of `~PySide6.QtGui.QColor` or a
+        string representation of hex, rgb, or rgba color code.  It can
+        also be a string representation of a `~PySide6.QtGui.QColor`,
+        e.g. ``'QColor(r, g, b)'``.
+    """
     if isinstance(color, QColor):
         pass
     elif not isinstance(color, str):

--- a/bapsf_motion/gui/helpers.py
+++ b/bapsf_motion/gui/helpers.py
@@ -1,3 +1,7 @@
+"""
+A collection of helper functions to assist with the design and
+implementation of the package GUIs.
+"""
 __all__ = ["get_qapplication", "get_color_scheme", "cast_color_to_rgba_string"]
 
 import ast

--- a/bapsf_motion/motion_builder/core.py
+++ b/bapsf_motion/motion_builder/core.py
@@ -417,7 +417,7 @@ class MotionBuilder(MBItem):
 
     def get_insertion_point(self) -> Union[np.ndarray, None]:
         """
-        Get the insertion point associated with the `GovernExclusion.
+        Get the insertion point associated with the `GovernExclusion`.
         Returns `None` if no insertion point exists.
         """
         try:

--- a/bapsf_motion/motion_builder/layers/base.py
+++ b/bapsf_motion/motion_builder/layers/base.py
@@ -24,8 +24,9 @@ class BaseLayer(MBItem):
 
     skip_ds_add: bool
         If `True`, then skip generating the `~xarray.DataArray`
-        corresponding to the motion points and skip adding it to the
-        `~xarray.Dataset`. (DEFAULT: `False`)
+        corresponding to the motion points and adding it to the
+        `~xarray.Dataset`.  This keyword is provided to facilitate
+        functionality of composite layers.  (DEFAULT: `False`)
 
     kwargs:
         Keyword arguments that are specific to the subclass.

--- a/bapsf_motion/transform/lapd.py
+++ b/bapsf_motion/transform/lapd.py
@@ -126,8 +126,8 @@ class LaPDXYTransform(base.BaseTransform):
           pivot_to_drive = 133.51
           pivot_to_feedthru = 21.6
           probe_axis_offset = 20.16
-          drive_polarity = (1, 1)
-          mspace_polarity = (-1, 1)
+          drive_polarity = [1, 1]
+          mspace_polarity = [-1, 1]
 
        .. code-tab:: py Dict Entry
 
@@ -180,8 +180,8 @@ class LaPDXYTransform(base.BaseTransform):
           pivot_to_drive = 133.51
           pivot_to_feedthru = 21.6
           probe_axis_offset = 20.16
-          drive_polarity = (1, -1)
-          mspace_polarity = (1, 1)
+          drive_polarity = [1, -1]
+          mspace_polarity = [1, 1]
 
        .. code-tab:: py Dict Entry
 

--- a/docs/api_static/bapsf_motion.gui.configure.bases.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.bases.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.bases`
+==================================
+
+.. currentmodule:: bapsf_motion.gui.configure.bases
+
+.. automodapi:: bapsf_motion.gui.configure.bases

--- a/docs/api_static/bapsf_motion.gui.configure.configure_.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.configure_.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.configure_`
+=======================================
+
+.. currentmodule:: bapsf_motion.gui.configure.configure_
+
+.. automodapi:: bapsf_motion.gui.configure.configure_

--- a/docs/api_static/bapsf_motion.gui.configure.drive_overlay.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.drive_overlay.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.drive_overlay`
+==========================================
+
+.. currentmodule:: bapsf_motion.gui.configure.drive_overlay
+
+.. automodapi:: bapsf_motion.gui.configure.drive_overlay

--- a/docs/api_static/bapsf_motion.gui.configure.helpers.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.helpers.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.helpers`
+====================================
+
+.. currentmodule:: bapsf_motion.gui.configure.helpers
+
+.. automodapi:: bapsf_motion.gui.configure.helpers

--- a/docs/api_static/bapsf_motion.gui.configure.motion_builder_overlay.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.motion_builder_overlay.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.motion_builder_overlay`
+===================================================
+
+.. currentmodule:: bapsf_motion.gui.configure.motion_builder_overlay
+
+.. automodapi:: bapsf_motion.gui.configure.motion_builder_overlay

--- a/docs/api_static/bapsf_motion.gui.configure.motion_group_widget.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.motion_group_widget.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.motion_group_widget`
+================================================
+
+.. currentmodule:: bapsf_motion.gui.configure.motion_group_widget
+
+.. automodapi:: bapsf_motion.gui.configure.motion_group_widget

--- a/docs/api_static/bapsf_motion.gui.configure.motion_space_display.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.motion_space_display.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.motion_space_display`
+=================================================
+
+.. currentmodule:: bapsf_motion.gui.configure.motion_space_display
+
+.. automodapi:: bapsf_motion.gui.configure.motion_space_display

--- a/docs/api_static/bapsf_motion.gui.configure.transform_overlay.rst
+++ b/docs/api_static/bapsf_motion.gui.configure.transform_overlay.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.configure.transform_overlay`
+==============================================
+
+.. currentmodule:: bapsf_motion.gui.configure.transform_overlay
+
+.. automodapi:: bapsf_motion.gui.configure.transform_overlay

--- a/docs/api_static/bapsf_motion.gui.helpers.rst
+++ b/docs/api_static/bapsf_motion.gui.helpers.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+`bapsf_motion.gui.helpers`
+==========================
+
+.. currentmodule:: bapsf_motion.gui.helpers
+
+.. automodapi:: bapsf_motion.gui.helpers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,6 +134,7 @@ intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "astropy": ("https://docs.astropy.org/en/stable/", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
+    "PySide6": ("https://doc.qt.io/qtforpython-6/", None),
     "sphinx_automodapi": (
         "https://sphinx-automodapi.readthedocs.io/en/latest/",
         None,

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -19,6 +19,11 @@ Glossary
    drive
       See :term:`probe drive`
 
+   event loop
+      An event loop is a programming design pattern that waits for and
+      dispatches events or messages in the program.  `bapsf_motion`
+      predominately utilizes the `asyncio` `event loop`_.
+
    exclusion layer
    exclusion layers
       See :term:`motion exclusion`

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # these are dependencies required to build package documentation
 # ought to mirror 'docs' under options.extras_require in setup.cfg
--r install.txt
+-r gui.txt
 git+https://github.com/PlasmaPy/plasmapy_sphinx@main#egg=plasmapy_sphinx
 docutils >= 0.18.1
 ipython

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
 # these are dependencies required to run package tests
 # ought to mirror 'tests' under options.extras_require in setup.cfg
--r install.txt
+-r gui.txt
 pytest >= 5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,10 +76,12 @@ gui =
   qtawesome
 tests =
   # ought to mirror requirements/tests.txt
+  %(gui)s
   pytest >= 5.1
 
 docs =
   # ought to mirror requirements/docs.txt
+  %(gui)s
   docutils >= 0.18.1
   ipython
   jinja2 >= 3.1.2


### PR DESCRIPTION
This PR updates documentation:

- adds term "event loop" to the glossary
- fixes some bad syntax in TOML exampls
- adds missing `api_static` entries