### PR TITLE
Cache `pip` install dependencies on GA worflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
+          cache: 'pip'
       - name: Upgrade pip
         run: |
           python -m pip install pip --upgrade


### PR DESCRIPTION
Configure `setup-python` to cache `pip` dependencies for the `import-bapsf_motion` workflow.