### PR TITLE
Add to `MotionSpaceDisplay` ability to skip plotting of certain values

### DIFF
--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -112,6 +112,8 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         # SET UP PLOT WIDGET
         self.mpl_canvas = MotionSpaceDisplay(parent=self)
+        self.mpl_canvas.display_position = False
+        self.mpl_canvas.display_target_position = False
         if isinstance(self.mg, MotionGroup) and isinstance(self.mg.mb, MotionBuilder):
             self.mpl_canvas.link_motion_builder(self.mg.mb)
 


### PR DESCRIPTION
This PR does...

- Adds properties `display_position`, `display_probe`, and `display_target_position` to `MotionSpaceDisplayy`.
- Setting any of the above properties `False` will prevent the associated value from being plotted.
- Setting `display_position` `False` will also set `display_probe` `False`.
- Setting `display_probe` `True` will also set `display_position` `True`.
- Setting `display_target_position` `False` also disables selecting motion list points to set the target position.
- The `MotionSpaceDisplay` instance in `MotionBuilderConfigOverlay` sets `display_position` and `display_target_position` `False`.