### PR TITLE
Patch modifying exclusion layers in the `MotionBuilderConfigOveraly`

### DIFF
--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -964,8 +964,9 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             _input = ast.literal_eval(_input_string)
         except (ValueError, SyntaxError) as err:
             params = _registry.get_input_parameters(_type)
-            _type = params[param]["param"].annotation
-            if inspect.isclass(_type) and issubclass(_type, str):
+            anno = params[param]["param"].annotation
+
+            if inspect.isclass(anno) and issubclass(anno, str):
                 _input = _input_string
             elif _input_string == "":
                 _input = None

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -862,7 +862,11 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         self.configChanged.emit()
 
     def _refresh_params_combo_box(
-        self, items, icons=None, current: Optional[str] = None, _type: Optional[str] = None,
+        self,
+        items,
+        icons=None,
+        current: Optional[str] = None,
+        _type: Optional[str] = None,
     ):
         # disable combo box signals during depopulation
         self.params_combo_box.blockSignals(True)

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -749,8 +749,9 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         )
         _icons = [None] * len(_available)
         _exclude_governors = (
-                bool(self.mb.exclusions)
-                and isinstance(self.mb.exclusions[0], GovernExclusion)
+            bool(self.mb.exclusions)
+            and isinstance(self.mb.exclusions[0], GovernExclusion)
+            and not isinstance(current_ex, GovernExclusion)
         )
         _govern_icon = qta.icon("mdi.crown")
         for ii, name in enumerate(tuple(_available)):

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1117,7 +1117,6 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
                 skip_ds_add=True,
                 **_inputs,
             )
-            # self._transform = transform
             self.change_validation_state(True)
         except (ValueError, TypeError) as err:
             self.logger.exception(

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -10,6 +10,7 @@ import math
 import numpy as np
 import matplotlib as mpl
 import re
+import typing
 import xarray as xr
 
 from PySide6.QtCore import Qt, Slot, QSize
@@ -967,6 +968,11 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             anno = params[param]["param"].annotation
 
             if inspect.isclass(anno) and issubclass(anno, str):
+                _input = _input_string
+            elif (
+                typing.get_origin(anno) is Union
+                and str in typing.get_args(anno)
+            ):
                 _input = _input_string
             elif _input_string == "":
                 _input = None

--- a/bapsf_motion/motion_builder/exclusions/lapd.py
+++ b/bapsf_motion/motion_builder/exclusions/lapd.py
@@ -273,9 +273,9 @@ class LaPDXYExclusion(GovernExclusion):
             raise ValueError
         elif 0 <= cone_angle >= 180:  # noqa
             raise ValueError
-        elif 0.5 * cone_angle > max_angle:
+        elif cone_angle > max_angle:
             cone_angle = max_angle
-        self.inputs["full_cone_angle"] = cone_angle
+        self.inputs["cone_full_angle"] = cone_angle
 
     def _combine_exclusions(self):
         """Combine all sub-exclusions into one exclusion array."""


### PR DESCRIPTION
Observed bug:  When trying to modify and existing govern exclusion in the `MotionBuilderConfigOverlay` the input parameters widget would not display.  This occurred because govern exclusions were being excluded from the type selection combo box.

Fixes:
- Govern exclusions will only be omitted from the drop-down selection if the exclusion being edited is NOT a govern exclusion and a govern exclusion is already defined in the list of exclusions.
- When validating a layer in `MotionBuilderConfigOverlay` a reduced resolution mask is passed to the layer factor.  This reduces computation time for building a layer, and thus make the GUI more responsive.
- Fix incorrect naming of `'cone_full_angle'` from #107 
- `MotionBuilderConfigOverlay` when validating input parameters allow strings if present in a `typing.Union` annotation.