### PR TITLE
Add ability to disable holding "idle" current of motors in the configuration GUI

### DIFF
--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -362,7 +362,6 @@ class AxisConfigWidget(QWidget):
         limit_mode = self.axis_config["motor_settings"]["limit_mode"]
         self.limit_mode_slider.setValue(limit_mode)
 
-
     def _validate_ip(self, ip):
         if ip == self.axis_config["ip"]:
             # ip did not change

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -988,6 +988,7 @@ class DriveDesktopController(DriveBaseController):
 
         self.zero_all_btn.clicked.connect(self.zeroDrive.emit)
         self.move_to_btn.clicked.connect(self._move_to)
+        self.hold_current_btn.clicked.connect(self._toggle_holding_current)
 
     def _define_layout(self) -> QLayout:
         _on = QLabel("O\nN", parent=self)
@@ -1099,6 +1100,14 @@ class DriveDesktopController(DriveBaseController):
             return
 
         self.moveTo.emit(target_pos)
+
+    def _toggle_holding_current(self):
+        hold_current = not self.hold_current_btn.isChecked()
+        if hold_current:
+            self.mg.drive.send_command("reset_currents")
+        else:
+            idle_currents = [0] * self.mg.drive.naxes
+            self.mg.drive.send_command("set_idle_current", *idle_currents)
 
     def set_target_position(self, target_position: List[float]):
         npos = len(target_position)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1128,12 +1128,14 @@ class DriveDesktopController(DriveBaseController):
     def disable_motion_buttons(self):
         self.move_to_btn.setEnabled(False)
         self.zero_all_btn.setEnabled(False)
+        self.hold_current_btn.setEnabled(False)
 
         super().disable_motion_buttons()
 
     def enable_motion_buttons(self):
         self.move_to_btn.setEnabled(True)
         self.zero_all_btn.setEnabled(True)
+        self.hold_current_btn.setEnabled(True)
 
         super().enable_motion_buttons()
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -6,6 +6,8 @@ __all__ = ["MGWidget"]
 
 import asyncio
 import logging
+import re
+
 import numpy as np
 import os
 import warnings
@@ -915,7 +917,6 @@ class DriveDesktopController(DriveBaseController):
     def _initialize_widgets(self):
         # BUTTON WIDGETS
         _btn = StyleButton("Move \n To", parent=self)
-        _btn.setFixedWidth(100)
         _btn.setMinimumHeight(100)
         font = _btn.font()
         font.setPointSize(20)
@@ -923,7 +924,6 @@ class DriveDesktopController(DriveBaseController):
         self.move_to_btn = _btn
 
         _btn = StyleButton("Home \n All", parent=self)
-        _btn.setFixedWidth(100)
         _btn.setMinimumHeight(100)
         _btn.setFont(font)
         _btn.setEnabled(False)
@@ -931,10 +931,57 @@ class DriveDesktopController(DriveBaseController):
         self.home_btn.setVisible(False)
 
         _btn = ZeroButton("Zero \n All", parent=self)
-        _btn.setFixedWidth(100)
         _btn.setMinimumHeight(100)
         _btn.setFont(font)
         self.zero_all_btn = _btn
+
+        _btn = StyleButton("Holding\nCurrent", parent=self)
+        _btn.setFixedHeight(44)
+        font = _btn.font()
+        font.setPointSize(10)
+        _btn.setFont(font)
+        _btn.update_style_sheet(
+            styles={
+                "background-color": re.sub(
+                    " +",
+                    " ",
+                    """qlineargradient(
+                        x1:0,
+                        y1:0, 
+                        x2:1, 
+                        y2:0,
+                        stop: 0 rgb(52, 161, 219),
+                        stop: 0.1 rgb(52, 161, 219),
+                        stop: 0.4 rgb(163, 163, 163),
+                        stop: 1 rgb(163, 163, 163)
+                    )""".replace("\n", "")
+                ),
+            },
+            action="base",
+        )
+        _btn.update_style_sheet(
+            styles={
+                "background-color": re.sub(
+                    " +",
+                    " ",
+                    """qlineargradient(
+                        x1:0,
+                        y1:0, 
+                        x2:1, 
+                        y2:0,
+                        stop: 0 rgb(163, 163, 163),
+                        stop: 0.6 rgb(163, 163, 163),
+                        stop: 0.9 rgb(250, 66, 45)
+                        stop: 1 rgb(250, 66, 45)
+                    )""".replace("\n", "")
+                ),
+            },
+            action="checked",
+        )
+        _btn.setCheckable(True)
+        _btn.setChecked(False)
+        self.hold_current_btn = _btn
+        self.logger.info(f"Holding curring style sheet:\n{self.hold_current_btn.styleSheet()}")
 
     def _connect_signals(self):
         super()._connect_signals()
@@ -943,13 +990,44 @@ class DriveDesktopController(DriveBaseController):
         self.move_to_btn.clicked.connect(self._move_to)
 
     def _define_layout(self) -> QLayout:
+        _on = QLabel("O\nN", parent=self)
+        font = _on.font()
+        font.setBold(True)
+        _on.setFont(font)
+        _on.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        _on.setFixedWidth(10)
+        _on.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+
+        _off = QLabel("O\nF\nF", parent=self)
+        _off.setFont(font)
+        _off.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        _off.setFixedWidth(10)
+        _off.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+
+        holding_current_layout = QHBoxLayout()
+        holding_current_layout.setContentsMargins(0, 0, 0, 0)
+        holding_current_layout.addWidget(
+            _on,
+            alignment=Qt.AlignmentFlag.AlignVCenter,
+        )
+        holding_current_layout.addWidget(self.hold_current_btn)
+        holding_current_layout.addWidget(
+            _off,
+            alignment=Qt.AlignmentFlag.AlignVCenter,
+        )
+
         # Sub-Layout #1
         sub_layout = QVBoxLayout()
+        sub_layout.setContentsMargins(0, 0, 0, 0)
         sub_layout.addWidget(self.move_to_btn)
         sub_layout.addStretch()
-        sub_layout.addWidget(self.home_btn)
+        # sub_layout.addWidget(self.home_btn)
+        sub_layout.addLayout(holding_current_layout)
         sub_layout.addStretch()
         sub_layout.addWidget(self.zero_all_btn)
+        sub_widget = QWidget(parent=self)
+        sub_widget.setLayout(sub_layout)
+        sub_widget.setFixedWidth(140)
 
         # Sub-Layout #2
         _text = QLabel("Position", parent=self)
@@ -990,7 +1068,7 @@ class DriveDesktopController(DriveBaseController):
         sub_layout2.addStretch(1)
 
         layout = QHBoxLayout()
-        layout.addLayout(sub_layout)
+        layout.addWidget(sub_widget)
         layout.addLayout(sub_layout2)
         for acw in self._axis_control_widgets:
             layout.addWidget(acw)


### PR DESCRIPTION
This PR does...

- Adds a toggle button to the `DriveDesktopController` that allows for toggling the holding "idle" current on and off for all drive axes.
- When off the motor currents are set to zero.
- When on the motor currents are reset to their default value.
- NOTE: All currents are disabled when a motor is disabled, and motors are disabled when the `Motor` actor is terminated.  During a motion group configuration all motors are terminated except for the one being configured.  Hence, we do not have to worry about other motors (under `bapsf_motion` control) creating noise.

Extra Note:  Disabling the holding current is done to prevent pickup on data signal lines during an LaPD run.