### PR TITLE
Patch `LaPDXYTransform` for West side deployment

### DIFF
--- a/bapsf_motion/transform/base.py
+++ b/bapsf_motion/transform/base.py
@@ -255,7 +255,8 @@ class BaseTransform(ABC):
                 f"Expected a 2D array of shape (N, {self.naxes}) for "
                 f"'points', but got a {points.ndim}-D array."
             )
-        elif self.naxes not in points.shape:
+
+        if self.naxes not in points.shape:
             raise ValueError(
                 f"Expected a 2D array of shape (N, {self.naxes}) for "
                 f"'points', but got shape {points.shape}."

--- a/bapsf_motion/transform/base.py
+++ b/bapsf_motion/transform/base.py
@@ -242,6 +242,9 @@ class BaseTransform(ABC):
         # make sure points is a numpy array
         if not isinstance(points, np.ndarray):
             points = np.array(points)
+        else:
+            # copy the array so we do NOT write to the original array
+            points = points.copy()
 
         # make sure points is always an N X M matrix
         if points.ndim == 1 and points.size == self.naxes:

--- a/bapsf_motion/transform/lapd.py
+++ b/bapsf_motion/transform/lapd.py
@@ -285,7 +285,7 @@ class LaPDXYTransform(base.BaseTransform):
                 )
             elif key == "pivot_to_center":
                 self._deployed_side = "East" if val >= 0.0 else "West"
-                inputs["pivot_to_center"] = np.abs(val)
+                val = np.abs(val)
             elif val < 0.0:
                 # TODO: HOW (AND SHOULD WE) ALLOW A NEGATIVE OFFSET FOR
                 #       "probe_axis_offset"

--- a/bapsf_motion/transform/lapd.py
+++ b/bapsf_motion/transform/lapd.py
@@ -234,37 +234,41 @@ class LaPDXYTransform(base.BaseTransform):
             return super().__call__(points=points, to_coords=to_coords)
 
         if to_coords == "drive":
+            _sign = 1 if self.deployed_side == "East" else -1
+            pivot_to_center = np.abs(self.pivot_to_center)
+
             # - points is in LaPD motion space coordinates
             # - need to convert motion space coordinates to non-droop
             #   scenario before doing matrix multiplication
             points = self._condition_points(points)
 
             # 1. convert to ball valve coords
-            _sign = 1 if self.deployed_side == "East" else -1
-            points[..., 0] = np.absolute(_sign * self.pivot_to_center - points[..., 0])
+            points[..., 0] = np.absolute(_sign * pivot_to_center - points[..., 0])
 
             # 2. droop correct to non-droop coords
             points = self.droop_correct(points, to_points="non-droop")
 
             # 3. back to LaPD coords
-            points[..., 0] = _sign * (self.pivot_to_center - points[..., 0])
+            points[..., 0] = _sign * (pivot_to_center - points[..., 0])
 
         tr_points = super().__call__(points=points, to_coords=to_coords)
             
         if to_coords != "drive":  # to motion space
+            _sign = 1 if self.deployed_side == "East" else -1
+            pivot_to_center = np.abs(self.pivot_to_center)
+
             # - tr_points is in LaPD motion space coordinates
             # - need to convert motion space coordinates to droop scenario
             # 1. convert to ball valve coords
-            _sign = 1 if self.deployed_side == "East" else -1
             tr_points[..., 0] = np.absolute(
-                _sign * self.pivot_to_center - tr_points[..., 0]
+                _sign * pivot_to_center - tr_points[..., 0]
             )
 
             # 2. droop correct to droop coords
             tr_points = self.droop_correct(tr_points, to_points="droop")
 
             # 3. back to LaPD coords
-            tr_points[..., 0] = _sign * (self.pivot_to_center - tr_points[..., 0])
+            tr_points[..., 0] = _sign * (pivot_to_center - tr_points[..., 0])
 
         return tr_points
 
@@ -285,7 +289,9 @@ class LaPDXYTransform(base.BaseTransform):
                 )
             elif key == "pivot_to_center":
                 self._deployed_side = "East" if val >= 0.0 else "West"
-                val = np.abs(val)
+                # do not take the absolute value here, so the config
+                # dict properly maintains the negative value
+                # val = np.abs(val)
             elif val < 0.0:
                 # TODO: HOW (AND SHOULD WE) ALLOW A NEGATIVE OFFSET FOR
                 #       "probe_axis_offset"
@@ -339,13 +345,15 @@ class LaPDXYTransform(base.BaseTransform):
         points = self.mspace_polarity * points  # type: np.ndarray
         npoints = points.shape[0]
 
-        tan_theta = points[..., 1] / (points[..., 0] + self.pivot_to_center)
+        pivot_to_center = np.abs(self.pivot_to_center)
+
+        tan_theta = points[..., 1] / (points[..., 0] + pivot_to_center)
         theta = -np.arctan(tan_theta)
 
         T0 = np.zeros((npoints, 3, 3)).squeeze()
         T0[..., 0, 2] = np.sqrt(
-            points[..., 1]**2 + (self.pivot_to_center + points[..., 0])**2
-        ) - self.pivot_to_center
+            points[..., 1]**2 + (pivot_to_center + points[..., 0])**2
+        ) - pivot_to_center
         T0[..., 1, 2] = (
             self.pivot_to_drive * np.tan(theta)
             + self.probe_axis_offset * (1 - (1 / np.cos(theta)))
@@ -369,6 +377,8 @@ class LaPDXYTransform(base.BaseTransform):
         points = self.drive_polarity * points  # type: np.ndarray
         npoints = points.shape[0]
 
+        pivot_to_center = np.abs(self.pivot_to_center)
+
         # Angle Defs:
         # - theta = angle between the horizontal and the probe shaft
         # - beta = angle between the horizontal and the probe drive pivot
@@ -391,9 +401,9 @@ class LaPDXYTransform(base.BaseTransform):
 
         T0 = np.zeros((npoints, 3, 3)).squeeze()
         T0[..., 0, 0] = np.cos(theta)
-        T0[..., 0, 2] = -self.pivot_to_center * (1 - np.cos(theta))
+        T0[..., 0, 2] = -pivot_to_center * (1 - np.cos(theta))
         T0[..., 1, 0] = np.sin(theta)
-        T0[..., 1, 2] = self.pivot_to_center * np.sin(theta)
+        T0[..., 1, 2] = pivot_to_center * np.sin(theta)
         T0[..., 2, 2] = 1.0
 
         T_dpolarity = np.diag(self.drive_polarity.tolist() + [1.0])

--- a/bapsf_motion/transform/lapd_droop.py
+++ b/bapsf_motion/transform/lapd_droop.py
@@ -235,6 +235,9 @@ class DroopCorrectABC(ABC):
         # make sure points is a numpy array
         if not isinstance(points, np.ndarray):
             points = np.array(points)
+        else:
+            # copy the array so we do NOT write to the original array
+            points = points.copy()
 
         # make sure points is always an N X M matrix
         if points.ndim == 1 and points.size == self.naxes:

--- a/bapsf_motion/transform/lapd_droop.py
+++ b/bapsf_motion/transform/lapd_droop.py
@@ -248,7 +248,8 @@ class DroopCorrectABC(ABC):
                 f"Expected a 2D array of shape (N, {self.naxes}) for "
                 f"'points', but got a {points.ndim}-D array."
             )
-        elif self.naxes not in points.shape:
+
+        if self.naxes not in points.shape:
             raise ValueError(
                 f"Expected a 2D array of shape (N, {self.naxes}) for "
                 f"'points', but got shape {points.shape}."

--- a/bapsf_motion/transform/lapd_droop.py
+++ b/bapsf_motion/transform/lapd_droop.py
@@ -530,12 +530,19 @@ class LaPDXYDroopCorrect(DroopCorrectABC):
         #      - non-droop x > droop x for theta < 0
         #
         i = 0
-        while not np.allclose(test_points, points, rtol=0, atol=1e-8):
+        while not np.allclose(test_points, points, rtol=0, atol=1e-9):
             i += 1
-            ndroop_points[..., 0] += -1.5 * (test_points[..., 0] - points[..., 0])
-            ndroop_points[..., 1] += -1.5 * (test_points[..., 1] - points[..., 1])
+            mask = np.logical_not(
+                np.all(
+                    np.isclose(test_points, points, rtol=0, atol=1e-9),
+                    axis=1,
+                )
+            )
+            ndroop_points[mask, 0] += -1.1 * (test_points[mask, 0] - points[mask, 0])
+            ndroop_points[mask, 1] += -1.1 * (test_points[mask, 1] - points[mask, 1])
 
-            test_points = self._convert_to_droop_points(ndroop_points)
+            updated_test_points = self._convert_to_droop_points(ndroop_points[mask, :])
+            test_points[mask, :] = updated_test_points[..., :]
 
             if i == 100:
                 print(i)


### PR DESCRIPTION
To get the `LaPDXYTransfrom` to work when deployed on the West side you need to use a negative `pivot_to_center` distance.  This is not needed for the base transform, but to accurate do the droop calculation part of the transform.  This is because to do the droop calculation we must first convert to the ball valve coordinates.

TL;DR: The base transform just needs the absolute distance of the `pivot_to_center` but the droop calculation needs the relative (signed) `pivot_to_center`.

This PR updates `LaPDXYTransform` to properly handle this signed `pivot_to_center` so the base transform and droop calculation get what they need.

---

Additionally, the `LaPDXYDroopCorrect._conver_to_nondroop_points` is updated so once a point reaches the satisfactory `isclose` condition then that point is no longer calculated while the remaining points are calculated.  This is to provide consistency when converting an single point or an array of points, since the array of points will naturally go through more iterations to meet an `isclose` condition on the full array.