### PR TITLE
Allow for default run name in the defaults TOML file

### DIFF
--- a/bapsf_motion/examples/bapsf_motion.toml
+++ b/bapsf_motion/examples/bapsf_motion.toml
@@ -1,5 +1,8 @@
-[bapsf_motion.defaults.drive]
-default = "benchtop_2D"
+[bapsf_motion.defaults]
+run_name = "bapsf_motion run configuration"
+drive.default = "benchtop_2D"
+motion_builder.default = "East - Generic XY"
+transform.default = "identity"
 
 [bapsf_motion.defaults.drive.0]
 name = "benchtop_2D"
@@ -25,9 +28,6 @@ axes.1.ip = "192.168.0.140"
 axes.1.units = "cm"
 axes.1.units_per_rev = 0.508
 
-[bapsf_motion.defaults.transform]
-default = "identity"
-
 [bapsf_motion.defaults.transform.0]
 name = "East - Generic XY"
 type = "lapd_xy"
@@ -51,9 +51,6 @@ pivot_to_drive = 112.7624  # 0.81 in + 22 cm + .75" + 82.5cm + 4.3cm
 pivot_to_feedthru = 21.6574  # 19.6 cm + 0.81"
 droop_correct = true
 droop_scale = 1.0
-
-[bapsf_motion.defaults.motion_builder]
-default = "East - Generic XY"
 
 [bapsf_motion.defaults.motion_builder.0]
 name = "East - Generic XY"

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -279,6 +279,12 @@ class ConfigureGUI(QMainWindow):
         self._log_widget = QLogger(self._logger, parent=self)
         self._run_widget = RunWidget(parent=self)
         self._mg_widget = None  # type: Union[MGWidget, None]
+        if (
+            self.defaults is not None
+            and "run_name" in self.defaults
+            and self.defaults["run_name"] != ""
+        ):
+            self._run_widget.set_visible_run_name(False)
 
         self._stacked_widget = QStackedWidget(parent=self)
         self._stacked_widget.addWidget(self._run_widget)

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -243,13 +243,6 @@ class RunWidget(QWidget):
         except AttributeError:
             return None
 
-    def set_visible_run_name(self, value: bool):
-        if not isinstance(value, bool):
-            return
-
-        self.run_name_widget.setVisible(value)
-        self.run_name_label.setVisible(value)
-
     def closeEvent(self, event):
         self.logger.info("Closing RunWidget")
         event.accept()

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -57,10 +57,13 @@ _HERE = Path(__file__).parent
 
 
 class RunWidget(QWidget):
-    def __init__(self, parent: "ConfigureGUI"):
+    def __init__(self, parent: "ConfigureGUI", *, enable_run_name: bool = True):
         super().__init__(parent=parent)
 
         self._logger = gui_logger
+        self._enable_run_name = (
+            enable_run_name if isinstance(enable_run_name, bool) else True
+        )
 
         # Define BUTTONS
 
@@ -109,6 +112,7 @@ class RunWidget(QWidget):
         font.setPointSize(16)
         _txt_widget.setFont(font)
         self.run_name_widget = _txt_widget
+        self.run_name_widget.setVisible(self._enable_run_name)
 
         _txt = QLabel("Run Name:  ", parent=self)
         _txt.setAlignment(
@@ -119,6 +123,7 @@ class RunWidget(QWidget):
         font.setPointSize(16)
         _txt.setFont(font)
         self.run_name_label = _txt
+        self.run_name_label.setVisible(self._enable_run_name)
 
         self.setLayout(self._define_layout())
 
@@ -198,12 +203,14 @@ class RunWidget(QWidget):
         font.setPointSize(16)
         mg_label.setFont(font)
 
-        sub_layout = QHBoxLayout()
-        sub_layout.addWidget(self.run_name_label)
-        sub_layout.addWidget(self.run_name_widget)
-        layout.addSpacing(18)
-        layout.addLayout(sub_layout)
-        layout.addSpacing(18)
+        if self._enable_run_name:
+            sub_layout = QHBoxLayout()
+            sub_layout.addWidget(self.run_name_label)
+            sub_layout.addWidget(self.run_name_widget)
+            layout.addSpacing(18)
+            layout.addLayout(sub_layout)
+            layout.addSpacing(18)
+
         layout.addWidget(mg_label)
         layout.addWidget(self.mg_list_widget)
 
@@ -275,16 +282,16 @@ class ConfigureGUI(QMainWindow):
 
         self._define_main_window()
 
-        # define "important" qt widgets
-        self._log_widget = QLogger(self._logger, parent=self)
-        self._run_widget = RunWidget(parent=self)
-        self._mg_widget = None  # type: Union[MGWidget, None]
-        if (
+        enable_run_name = False if (
             self.defaults is not None
             and "run_name" in self.defaults
             and self.defaults["run_name"] != ""
-        ):
-            self._run_widget.set_visible_run_name(False)
+        ) else True
+
+        # define "important" qt widgets
+        self._log_widget = QLogger(self._logger, parent=self)
+        self._run_widget = RunWidget(parent=self, enable_run_name=enable_run_name)
+        self._mg_widget = None  # type: Union[MGWidget, None]
 
         self._stacked_widget = QStackedWidget(parent=self)
         self._stacked_widget.addWidget(self._run_widget)

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -110,6 +110,16 @@ class RunWidget(QWidget):
         _txt_widget.setFont(font)
         self.run_name_widget = _txt_widget
 
+        _txt = QLabel("Run Name:  ", parent=self)
+        _txt.setAlignment(
+            Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft
+        )
+        _txt.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        font = _txt.font()
+        font.setPointSize(16)
+        _txt.setFont(font)
+        self.run_name_label = _txt
+
         self.setLayout(self._define_layout())
 
         self._connect_signals()
@@ -180,15 +190,6 @@ class RunWidget(QWidget):
     def _define_control_layout(self):
         layout = QVBoxLayout()
 
-        run_label = QLabel("Run Name:  ", parent=self)
-        run_label.setAlignment(
-            Qt.AlignmentFlag.AlignVCenter | Qt. AlignmentFlag.AlignLeft
-        )
-        run_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        font = run_label.font()
-        font.setPointSize(16)
-        run_label.setFont(font)
-
         mg_label = QLabel("Defined Motion Groups", parent=self)
         mg_label.setAlignment(
             Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignCenter
@@ -198,7 +199,7 @@ class RunWidget(QWidget):
         mg_label.setFont(font)
 
         sub_layout = QHBoxLayout()
-        sub_layout.addWidget(run_label)
+        sub_layout.addWidget(self.run_name_label)
         sub_layout.addWidget(self.run_name_widget)
         layout.addSpacing(18)
         layout.addLayout(sub_layout)

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -236,6 +236,13 @@ class RunWidget(QWidget):
         except AttributeError:
             return None
 
+    def set_visible_run_name(self, value: bool):
+        if not isinstance(value, bool):
+            return
+
+        self.run_name_widget.setVisible(value)
+        self.run_name_label.setVisible(value)
+
     def closeEvent(self, event):
         self.logger.info("Closing RunWidget")
         event.accept()

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -297,7 +297,11 @@ class ConfigureGUI(QMainWindow):
             config = None
 
         if config is None:
-            config = {"name": "A New Run"}
+            run_name = (
+                "A New Run" if self.defaults is None
+                else self.defaults.get("run_name", "A New Run")
+            )
+            config = {"name": run_name}
 
         self.replace_rm(config=config)
 

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -519,10 +519,16 @@ class ConfigureGUI(QMainWindow):
                 f"Expected 'defaults' to be of type dict, got type {type(defaults)}."
             )
 
-        if "bapsf_motion" not in defaults.keys():
+        if (
+            "bapsf_motion" not in defaults.keys()
+            or not isinstance(defaults["bapsf_motion"], dict)
+        ):
             # dictionary does not contain a setup for bapsf_motion
             defaults = None
-        elif "defaults" not in defaults["bapsf_motion"].keys():
+        elif (
+            "defaults" not in defaults["bapsf_motion"].keys()
+            or not isinstance(defaults["bapsf_motion"]["defaults"], dict)
+        ):
             # dictionary does not contain a defaults setup for bapsf_motion
             defaults = None
         else:


### PR DESCRIPTION
This PR allows for a default motion configuration run name to be defined in the defaults TOML file.  If this option is used, then the "Run Name" entry field will be hidden on the GUI display.

This was done since operators were having confusion between the motion group names, the configuration name given by the ACQ II system, and the `bapsf_motion` run name.  Since the `bapsf_motion` run configuration name is only used by `bapsf_motion`, this name is really "meaningless" in the context of a BaPSF data run.  So, operator confusion can be mitigated if we supply an internal default name, and never present the option to name the configuration.