### PR TITLE
Allow Motion Lists of defined Motion Groups to be included in the MotionBuilder dropdown

### DIFF
--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QWidget,
     QSizePolicy,
-    QTextEdit,
+    QPlainTextEdit,
     QListWidget,
     QVBoxLayout,
     QLineEdit,
@@ -101,7 +101,7 @@ class RunWidget(QWidget):
 
         # Define TEXT WIDGETS
 
-        self.config_widget = QTextEdit(parent=self)
+        self.config_widget = QPlainTextEdit(parent=self)
         self.mg_list_widget = QListWidget(parent=self)
         _font = self.mg_list_widget.font()
         _font.setPointSize(14)
@@ -437,7 +437,7 @@ class ConfigureGUI(QMainWindow):
 
     def update_display_config_text(self):
         self.logger.info(f"Updating the run config toml: {self.rm.config.as_toml_string}")
-        self._run_widget.config_widget.setText(self.rm.config.as_toml_string)
+        self._run_widget.config_widget.setPlainText(self.rm.config.as_toml_string)
 
     def update_display_rm_name(self):
         rm_name = self.rm.config["name"]

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -270,7 +270,8 @@ class ConfigureGUI(QMainWindow):
         self._rm_logger = logging.getLogger("RM")
 
         # setup defaults
-        self._defaults = None
+        self._defaults = None  # original defaults
+        self._defaults_updated = None  # updated with configs from configured MGs
         self._set_defaults(defaults=defaults)
 
         self._define_main_window()
@@ -355,6 +356,8 @@ class ConfigureGUI(QMainWindow):
 
     @property
     def defaults(self) -> Dict[str, Any]:
+        if self._defaults_updated is not None:
+            return self._defaults_updated
         return self._defaults
 
     @property
@@ -545,6 +548,50 @@ class ConfigureGUI(QMainWindow):
             defaults = defaults["bapsf_motion"]["defaults"]
 
         self._defaults = defaults
+
+    def _update_motion_builder_defaults(self):
+        if not isinstance(self.rm, RunManager):
+            self._defaults_updated = None
+            return
+
+        if len(self.rm.mgs) == 0:
+            self._defaults_updated = None
+            return
+
+        if self.defaults is None:
+            self._defaults_updated = {"motion_builder": {}}
+        else:
+            self._defaults_updated = _deepcopy_dict(self._defaults)
+
+        if "motion_builder" not in self._defaults:
+            self._defaults_updated["motion_builder"] = {}
+        else:
+            self._defaults_updated["motion_builder"] = _deepcopy_dict(
+                self._defaults["motion_builder"]
+            )
+
+        mb_defaults = self._defaults_updated["motion_builder"]
+        n_mb_configs = len(mb_defaults) - 1
+        for mg in self.rm.mgs.values():
+            drive_name, ml_name = MGWidget.split_motion_group_name(mg.config["name"])
+
+            _id = None
+            for _default_id in mb_defaults.keys():
+                if _default_id == "default":
+                    continue
+
+                if ml_name == mb_defaults[_default_id]["name"]:
+                    _id = _default_id
+                    break
+
+            if _id is None:
+                _id = f"{n_mb_configs}"
+                n_mb_configs += 1
+
+            mb_defaults[_id] = {
+                "name": ml_name,
+                **_deepcopy_dict(mg.config["motion_builder"]),
+            }
 
     def _spawn_mg_widget(self, mg: MotionGroup = None):
         config = None if not isinstance(mg, MotionGroup) else mg.config

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -562,12 +562,12 @@ class ConfigureGUI(QMainWindow):
             self._defaults_updated = None
             return
 
-        if self.defaults is None:
-            self._defaults_updated = {"motion_builder": {}}
-        else:
+        if self._defaults is not None:
             self._defaults_updated = _deepcopy_dict(self._defaults)
 
-        if "motion_builder" not in self._defaults:
+        if self._defaults is None:
+            self._defaults_updated = {"motion_builder": {}}
+        elif "motion_builder" not in self._defaults:
             self._defaults_updated["motion_builder"] = {}
         else:
             self._defaults_updated["motion_builder"] = _deepcopy_dict(

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -328,9 +328,7 @@ class ConfigureGUI(QMainWindow):
 
         self._run_widget.run_name_widget.editingFinished.connect(self.change_run_name)
 
-        self.configChanged.connect(self.update_display_config_text)
-        self.configChanged.connect(self.update_display_rm_name)
-        self.configChanged.connect(self.update_display_mg_list)
+        self.configChanged.connect(self._config_changed_handler)
 
     def _define_main_window(self):
         self.setWindowTitle("Run Configuration")
@@ -380,6 +378,12 @@ class ConfigureGUI(QMainWindow):
     @property
     def logging_config_dict(self):
         return self._logging_config_dict
+
+    def _config_changed_handler(self):
+        self.update_display_config_text()
+        self.update_display_rm_name()
+        self.update_display_mg_list()
+        self._update_motion_builder_defaults()
 
     def replace_rm(self, config):
         if isinstance(self.rm, RunManager):

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -383,7 +383,7 @@ class ConfigureGUI(QMainWindow):
         self.update_display_config_text()
         self.update_display_rm_name()
         self.update_display_mg_list()
-        self._update_motion_builder_defaults()
+        self.update_motion_builder_defaults()
 
     def replace_rm(self, config):
         if isinstance(self.rm, RunManager):
@@ -553,7 +553,7 @@ class ConfigureGUI(QMainWindow):
 
         self._defaults = defaults
 
-    def _update_motion_builder_defaults(self):
+    def update_motion_builder_defaults(self):
         if not isinstance(self.rm, RunManager):
             self._defaults_updated = None
             return

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -28,8 +28,8 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QPlainTextEdit,
     QSizePolicy,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
     QStackedWidget,
@@ -1812,7 +1812,7 @@ class MGWidget(QWidget):
 
         # Define TEXT WIDGETS
 
-        _widget = QTextEdit(parent=self)
+        _widget = QPlainTextEdit(parent=self)
         _widget.setSizePolicy(
             QSizePolicy.Policy.Preferred,
             QSizePolicy.Policy.Expanding,
@@ -2799,7 +2799,7 @@ class MGWidget(QWidget):
         self._populate_transform_dropdown()
 
     def _update_toml_widget(self):
-        self.toml_widget.setText(toml.as_toml_string(self.mg_config))
+        self.toml_widget.setPlainText(toml.as_toml_string(self.mg_config))
 
     def _update_ml_name_widget(self):
         drive_name, ml_name = self._split_motion_group_name()

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2802,7 +2802,7 @@ class MGWidget(QWidget):
         self.toml_widget.setPlainText(toml.as_toml_string(self.mg_config))
 
     def _update_ml_name_widget(self):
-        drive_name, ml_name = self._split_motion_group_name()
+        drive_name, ml_name = self.split_motion_group_name(self.mg_config["name"])
         self.ml_name_widget.setText(ml_name)
 
     def _update_drive_control_widget(self):
@@ -2858,16 +2858,17 @@ class MGWidget(QWidget):
 
         self.configChanged.emit()
 
-    def _split_motion_group_name(self):
+    @staticmethod
+    def split_motion_group_name(mg_name):
         match = re.compile(
             r"(<)(?P<drive_name>[\w\s-]+)(>)\s+(?P<ml_name>[\w\s-]+)"
-        ).fullmatch(self.mg_config["name"])
+        ).fullmatch(mg_name)
         if match is not None:
             drive_name = match.group("drive_name").strip()
             ml_name = match.group("ml_name").strip()
         else:
             drive_name = None
-            ml_name = self.mg_config["name"].strip()
+            ml_name = mg_name.strip()
 
         return drive_name, ml_name
 


### PR DESCRIPTION
This PR allows the motion builder dropdown (in the Configure GUI) to not only be populated with a defaults file, but also any motion builder configuration of configured motion groups.

## Items changed

- `MGWidget._split_motion_group_name` is renamed to `MGWidget._split_motion_group_name` and made a static method.  This allows the method to be used by `RunWidget` to analyze the motion group list.
- Put all slots connected to `ConfigureGUI.configChanged` into a single method `ConfigureGUI._config_changed_handler()`.
- Add attribute `ConfigureGUI._defaults_updated`.  In this case, `ConfigureGUI._default` contains the defaults only associated with the `defaults` keyword input argument, and `_defaults_updated` is the updated version of `_defaults` which contains additional defaults scraped from the configured motion groups.
- Add slot `ConfigureGUI.update_motion_builder_defaults` (connected to `ConfigureGUI.configChanged`) to scrape the configured motion groups for additional motion builder defaults.