### PR TITLE
Patch display of special characters `<` and `>`

### DIFF
--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
     QGridLayout,
     QWidget,
     QSizePolicy,
-    QTextEdit,
+    QPlainTextEdit,
     QListWidget,
     QVBoxLayout,
     QLineEdit,
@@ -101,7 +101,7 @@ class RunWidget(QWidget):
 
         # Define TEXT WIDGETS
 
-        self.config_widget = QTextEdit(parent=self)
+        self.config_widget = QPlainTextEdit(parent=self)
         self.mg_list_widget = QListWidget(parent=self)
         _font = self.mg_list_widget.font()
         _font.setPointSize(14)
@@ -437,7 +437,7 @@ class ConfigureGUI(QMainWindow):
 
     def update_display_config_text(self):
         self.logger.info(f"Updating the run config toml: {self.rm.config.as_toml_string}")
-        self._run_widget.config_widget.setText(self.rm.config.as_toml_string)
+        self._run_widget.config_widget.setPlainText(self.rm.config.as_toml_string)
 
     def update_display_rm_name(self):
         rm_name = self.rm.config["name"]

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -28,8 +28,8 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QPlainTextEdit,
     QSizePolicy,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
     QStackedWidget,
@@ -1812,7 +1812,7 @@ class MGWidget(QWidget):
 
         # Define TEXT WIDGETS
 
-        _widget = QTextEdit(parent=self)
+        _widget = QPlainTextEdit(parent=self)
         _widget.setSizePolicy(
             QSizePolicy.Policy.Preferred,
             QSizePolicy.Policy.Expanding,
@@ -2799,7 +2799,7 @@ class MGWidget(QWidget):
         self._populate_transform_dropdown()
 
     def _update_toml_widget(self):
-        self.toml_widget.setText(toml.as_toml_string(self.mg_config))
+        self.toml_widget.setPlainText(toml.as_toml_string(self.mg_config))
 
     def _update_ml_name_widget(self):
         drive_name, ml_name = self._split_motion_group_name()


### PR DESCRIPTION
Qt treats `<` and `>` as special characters in their text rich widgets, like `QLabel` and `QTextEdit`.  After #114 the TOML displays would randomly squish together the text display of the TOML config.  This is a result of `QTextEdit` not consistently rendering `<` and `>`.  To solve this the TOML widget displays are chained from using `QTextEdit` to `QPlainTextEdit`.