### PR TITLE
Patch re-generation of the `MotionBuilder` motion list

### DIFF
--- a/bapsf_motion/motion_builder/core.py
+++ b/bapsf_motion/motion_builder/core.py
@@ -447,6 +447,13 @@ class MotionBuilder(MBItem):
             points = np.unique(points, axis=0)
 
         mask = self.generate_excluded_mask(points)
+
+        if (
+            "motion_list" in self._ds.keys()
+            and self._ds["motion_list"].shape[0] != mask.shape[0]
+        ):
+            self.drop_vars("motion_list")
+
         self._ds["motion_list"] = xr.DataArray(
             data=points[mask, ...],
             dims=("index", "space")


### PR DESCRIPTION
When regenerating the `MotionBuilder` motion list the old motion list needs to be removed first if it does not have the same dimensionality as the new motion list.