### PR TITLE
Configure GUI: seed target position with current position if not specified

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -585,7 +585,7 @@ class AxisControlWidget(QWidget):
         if not isinstance(position, (u.Quantity, float)):
             return
         elif isinstance(position, u.Quantity):
-            _txt = f"{position.value:.2f} {position.unit}"
+            _txt = f"{position.value:.2f}"
         else:
             _txt = f"{position:.2f}"
 
@@ -628,7 +628,7 @@ class AxisControlWidget(QWidget):
         pos = self.position
         self.update_position_display(pos)
         if self.target_position_label.text() == "":
-            self.update_position_display(pos)
+            self.update_target_position_display(pos)
 
         limits = self.axis.motor.status["limits"]
         self.limit_fwd_btn.set_valid(state=limits["CW"])


### PR DESCRIPTION
This PR fixes the initialization of the target position display in the `AxisControlWidget`.  Now the target position display is initialized with the current probe position if the target position is null.