### PR TITLE
Patch masking of excluded motion list points

### DIFF
--- a/bapsf_motion/motion_builder/core.py
+++ b/bapsf_motion/motion_builder/core.py
@@ -508,7 +508,10 @@ class MotionBuilder(MBItem):
         ):
             self.drop_vars("motion_list")
 
-        self._ds["motion_list"] = xr.DataArray(data=points, dims=("index", "space"))
+        self._ds["motion_list"] = xr.DataArray(
+            data=points[mask, ...],
+            dims=("index", "space")
+        )
 
     def generate_excluded_mask(self, points) -> np.ndarray:
         """


### PR DESCRIPTION
PR #123 accidentally dropped the masking of excluded motion list points.  This PR adds the masking back.