### PR TITLE
Configure GUI :  Allow commas and periods in motion list names

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -2971,7 +2971,7 @@ class MGWidget(QWidget):
     @staticmethod
     def split_motion_group_name(mg_name):
         match = re.compile(
-            r"(<)(?P<drive_name>[\w\s-]+)(>)\s+(?P<ml_name>[\w\s-]+)"
+            r"(<)(?P<drive_name>[\w\s-]+)(>)\s+(?P<ml_name>[\w\s.,-]+)"
         ).fullmatch(mg_name)
         if match is not None:
             drive_name = match.group("drive_name").strip()


### PR DESCRIPTION
This PR updates `MGWidget.split_motion_group_name` to allow for commas `,` and periods `.` in the motion list name.