### PR TITLE
Include `objectName` specifier in the `StyleButton` style geneator

### DIFF
--- a/bapsf_motion/gui/widgets/buttons.py
+++ b/bapsf_motion/gui/widgets/buttons.py
@@ -39,7 +39,7 @@ class StyleButton(QPushButton):
             "background-color": "rgb(163, 163, 163)",
             "color": "rgb(50, 50, 50)",
         }
-        self._default_hover_style = {}
+        self._default_hover_style = {"border": "2px solid rgb(30, 60, 90)"}
         self._default_pressed_style = {"background-color": "rgb(111, 111, 111)"}
         self._default_checked_style = {}
         self._default_disabled_style = {"color": "rgb(123, 123, 123)"}

--- a/bapsf_motion/gui/widgets/buttons.py
+++ b/bapsf_motion/gui/widgets/buttons.py
@@ -95,16 +95,24 @@ class StyleButton(QPushButton):
         # color.setAlpha(100)
         # disable_string = f"color: rgba{color.getRgb()}"
 
+        object_name = self.objectName()
+        if object_name is not None:
+            object_name = f"#{object_name}"
+        else:
+            object_name = ""
+
+        header = f"{_cls_name}{object_name}"
+
         return f"""
-        {_cls_name} {{ {_base} }}
+        {header} {{ {_base} }}
 
-        {_cls_name}:hover {{ {_hover}  }}
+        {header}:hover {{ {_hover}  }}
 
-        {_cls_name}:pressed {{ {_pressed} }}
+        {header}:pressed {{ {_pressed} }}
 
-        {_cls_name}:checked {{ {_checked} }}
+        {header}:checked {{ {_checked} }}
         
-        {_cls_name}:disabled {{ {_disabled} }}
+        {header}:disabled {{ {_disabled} }}
         """
 
     @property

--- a/bapsf_motion/gui/widgets/buttons.py
+++ b/bapsf_motion/gui/widgets/buttons.py
@@ -96,10 +96,10 @@ class StyleButton(QPushButton):
         # disable_string = f"color: rgba{color.getRgb()}"
 
         object_name = self.objectName()
-        if object_name is not None:
-            object_name = f"#{object_name}"
-        else:
+        if object_name is None or not isinstance(object_name, str):
             object_name = ""
+        elif object_name != "":
+            object_name = f"#{object_name}"
 
         header = f"{_cls_name}{object_name}"
 


### PR DESCRIPTION
This PR updates `StyleButton` so if the `objectName` attribute is defined for the instantiated object, then the `#object_name` specifier is include in the generated stylesheet string.

A default hover style is also added to `StyleButton`.