### PR TITLE
Add Parameter Hints to Key Input Fields

### DIFF
--- a/bapsf_motion/gui/configure/helpers.py
+++ b/bapsf_motion/gui/configure/helpers.py
@@ -1,7 +1,7 @@
 """
 Module of helper functions for the Configuration GUI.
 """
-__all__ = ["gui_logger", "gui_logger_config_dict", "read_parameters_hints"]
+__all__ = ["gui_logger", "gui_logger_config_dict", "read_parameter_hints"]
 
 import logging
 
@@ -64,7 +64,7 @@ This dictionary is intended to be passed directly to
 """
 
 
-def read_parameters_hints() -> dict:
+def read_parameter_hints() -> dict:
     """
     Read the parameter hints file :file:`parameter_hints.toml` and
     return the dictionary of hints.

--- a/bapsf_motion/gui/configure/helpers.py
+++ b/bapsf_motion/gui/configure/helpers.py
@@ -1,9 +1,15 @@
 """
 Module of helper functions for the Configuration GUI.
 """
-__all__ = ["gui_logger", "gui_logger_config_dict"]
+__all__ = ["gui_logger", "gui_logger_config_dict", "read_parameters_hints"]
 
 import logging
+
+from pathlib import Path
+
+from bapsf_motion.utils import toml
+
+_HERE = Path(__file__)
 
 gui_logger = logging.getLogger("GUI")
 
@@ -56,3 +62,18 @@ association with the `bapsf_motion.gui.configure` functionality.
 This dictionary is intended to be passed directly to 
 `logging.config.dictConfig`.
 """
+
+
+def read_parameters_hints() -> dict:
+    """
+    Read the parameter hints file :file:`parameter_hints.toml` and
+    return the dictionary of hints.
+    """
+    filepath = (_HERE.parent / "parameter_hints.toml").resolve()
+    with open(filepath, "rb") as f:
+        hints = toml.load(f)
+
+    if "hints" not in hints:
+        return dict()
+
+    return hints["hints"]

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1349,7 +1349,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         self._param_inputs[param] = _input
 
         self.logger.info(
-            f"Updating input parameter {param} to {_input} for transformation "
+            f"Updating input parameter {param} to {_input} for layer/exclusion "
             f"type {_type}."
         )
 

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -35,7 +35,7 @@ import qtawesome as qta
 from bapsf_motion.actors import MotionGroup
 from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.bases import _ConfigOverlay
-from bapsf_motion.gui.configure.helpers import read_parameters_hints
+from bapsf_motion.gui.configure.helpers import read_parameter_hints
 from bapsf_motion.gui.configure.motion_space_display import MotionSpaceDisplay
 from bapsf_motion.gui.widgets import (
     DiscardButton,
@@ -69,7 +69,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         self._space_input_widgets = {}  # type: Dict[str, Dict[str, QLineEditSpecialized]]
         self._mpl_canvas_full_draw = True
 
-        _parameter_hints = read_parameters_hints()
+        _parameter_hints = read_parameter_hints()
         self._parameter_hints_layer = _parameter_hints.pop("layer", None)
         self._parameter_hints_exclusion = _parameter_hints.pop("exclusion", None)
 

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -637,7 +637,6 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             else self.parameter_hints_layer
         )
         _hints = None if _type not in _hints else _hints[_type]
-        self.logger.info(f"Hints == {_hints}")
 
         self._param_inputs.update(
             {"_type": _type, "_registry": _registry, "_hints": _hints}

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -35,6 +35,7 @@ import qtawesome as qta
 from bapsf_motion.actors import MotionGroup
 from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.bases import _ConfigOverlay
+from bapsf_motion.gui.configure.helpers import read_parameters_hints
 from bapsf_motion.gui.configure.motion_space_display import MotionSpaceDisplay
 from bapsf_motion.gui.widgets import (
     DiscardButton,
@@ -67,6 +68,10 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         self._space_input_widgets = {}  # type: Dict[str, Dict[str, QLineEditSpecialized]]
         self._mpl_canvas_full_draw = True
+
+        _parameter_hints = read_parameters_hints()
+        self._parameter_hints_layer = _parameter_hints.pop("layer", None)
+        self._parameter_hints_exclusion = _parameter_hints.pop("exclusion", None)
 
         # _param_inputs:
         #     dictionary of input parameters for instantiating an exclusion or
@@ -277,6 +282,18 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             return self.mg.mb
 
         return self._mb
+
+    @property
+    def parameter_hints_layer(self):
+        if self._parameter_hints_layer is None:
+            self._parameter_hints_layer = dict()
+        return self._parameter_hints_layer
+
+    @property
+    def parameter_hints_exclusion(self):
+        if self._parameter_hints_exclusion is None:
+            self._parameter_hints_exclusion = dict()
+        return self._parameter_hints_exclusion
 
     # -- LAYOUT AND WIDGET DEFINITIONS --
 
@@ -614,9 +631,16 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             if ex_or_ly == "exclusion"
             else self.layer_registry
         )
+        _hints = (
+            self.parameter_hints_exclusion
+            if ex_or_ly == "exclusion"
+            else self.parameter_hints_layer
+        )
+        _hints = None if _type not in _hints else _hints[_type]
+        self.logger.info(f"Hints == {_hints}")
 
         self._param_inputs.update(
-            {"_type": _type, "_registry": _registry}
+            {"_type": _type, "_registry": _registry, "_hints": _hints}
         )
 
         params = _registry.get_input_parameters(_type)
@@ -645,7 +669,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         ii = 0
         _row_height = 24
         for key, val in params.items():
-            # determine the seeded value for the transform input
+            # determine the seed/default value for the layer or exclusion input
             if key in self._param_inputs:
                 default = self._param_inputs[key]
             elif val["param"].default is not val["param"].empty:
@@ -654,6 +678,9 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             else:
                 default = None
                 self._param_inputs[key] = default
+
+            # determine parameter hint for layer or exclusion input
+            _hint = None if (_hints is None or key not in _hints) else _hints[key]
 
             _txt = QLabel(key, parent=_widget)
             _txt.setFixedHeight(_row_height)
@@ -689,6 +716,8 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
             font.setPointSize(14)
             _txt.setFont(font)
             _input = _txt
+            if _hint is not None:
+                _input.setPlaceholderText(_hint)
             _input.editingFinishedPayload.connect(self._update_param_inputs)
 
             _txt = QLabel("", parent=_widget)
@@ -1425,6 +1454,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         _inputs = self._param_inputs.copy()
         _type = _inputs.pop("_type")
         _registry = _inputs.pop("_registry")
+        _hints = _inputs.pop("_hints")
         params = _registry.get_input_parameters(_type)
 
         for key, val in _inputs.items():

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1577,6 +1577,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         _inputs = self._param_inputs.copy()
         _type = _inputs.pop("_type")
         _registry = _inputs.pop("_registry")
+        _hints = _inputs.pop("_hints")
         _name = self.params_label.text()
 
         if _registry is self.exclusion_registry and _name == "New Exclusion":

--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1078,6 +1078,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         # TODO: remove params_widget if the removed exclusion is currently
         #       populating the params_widget
 
+        self._mpl_canvas_full_draw = True
         self.configChanged.emit()
 
     @Slot()
@@ -1528,6 +1529,8 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         else:
             self.mpl_canvas.update_motion_list()
 
+        self._mpl_canvas_full_draw = False
+
     def update_exclusion_list_box(self):
         self.logger.info("Updating Exclusion List Box")
         self.remove_ex_btn.setEnabled(False)
@@ -1578,10 +1581,12 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         if _registry is self.exclusion_registry and _name == "New Exclusion":
             self.mb.add_exclusion(_type, **_inputs)
+            self._mpl_canvas_full_draw = True
         elif _registry is self.exclusion_registry:
             # modifying existing exclusion
             self.mb.remove_exclusion(_name)
             self.mb.add_exclusion(_type, **_inputs)
+            self._mpl_canvas_full_draw = True
         elif _name == "New Layer":
             self.mb.add_layer(_type, **_inputs)
             self._mpl_canvas_full_draw = False
@@ -1677,6 +1682,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         self._mb = MotionBuilder(**mb_config)
         self.mpl_canvas.link_motion_builder(self._mb)
+        self._mpl_canvas_full_draw = True
         self.configChanged.emit()
         return self._mb
 

--- a/bapsf_motion/gui/configure/parameter_hints.toml
+++ b/bapsf_motion/gui/configure/parameter_hints.toml
@@ -1,3 +1,28 @@
+# This TOML file contains the hints used to populate the placeholder text
+# for input fields associated with configuring layers, exlusions, and
+# transforms.
+#
+# Adding any hints should folow the pattern:
+#
+# [hints.<entity>.<type>]
+# param1 = "placeholder text"
+# param2 = "placeholder text"
+#
+# where,
+#   <entity> :
+#       is the layer, exclusion, or transform
+#   <type> :
+#       is the "type" of <entity> class.  e.g. the transform LaPDXYTransform
+#       has <type> == lapd_xy, and exclusion CircularLayer has
+#       <type> == circle
+#   param1, param2, ... :
+#       are the input arguments for the class being configurated,  e.g.
+#       CircularExlusion would have param1 == radius, param2 == center,
+#       and param3 == exlude
+#
+#       Note that not all input parameters need configured.  You only
+#       need to configure input you want to add placeholder test for.
+#
 [hints.transform.lapd_xy]
 pivot_to_center = "58.771  # ball valve pivot to LaPD center"
 pivot_to_drive = "116.84  # ball valve pivot to vertical drive centerline"

--- a/bapsf_motion/gui/configure/parameter_hints.toml
+++ b/bapsf_motion/gui/configure/parameter_hints.toml
@@ -6,14 +6,14 @@ probe_axis_offset = "21.5"
 
 [hints.exclusion.circle]
 radius = "5.0"
-center = "[0, 0]"
-exclude = "inside  # possible options outside or inside"
+center = "[x, y]"
+exclude = "inside  # possible options: outside or inside"
 
 [hints.exclusion.divider]
-mb = "[slope, intercept]  # use inf for vertical line"
+mb = "[slope, intercept]  # use [inf, x] for vertical line"
 exclude = "-e0  # negative/left side of the line"
 
-[hints.exclusion.shadow]
+[hints.exclusion.shadow_2d]
 source_point = "[x, y]  # source of shadow caster"
 
 [hints.layer.grid]

--- a/bapsf_motion/gui/configure/parameter_hints.toml
+++ b/bapsf_motion/gui/configure/parameter_hints.toml
@@ -1,8 +1,8 @@
 [hints.transform.lapd_xy]
-pivot_to_center = "58.771"
-pivot_to_drive = "116.84"
-pivot_to_feedthru = "53.8"
-probe_axis_offset = "21.5"
+pivot_to_center = "58.771  # ball valve pivot to LaPD center"
+pivot_to_drive = "116.84  # ball valve pivot to vertical drive centerline"
+pivot_to_feedthru = "53.8  # ball valve pivot to front of probe feedthru"
+probe_axis_offset = "21.5  # distance from probe shaft to vertical drive pivot"
 
 [hints.exclusion.circle]
 radius = "5.0"

--- a/bapsf_motion/gui/configure/parameter_hints.toml
+++ b/bapsf_motion/gui/configure/parameter_hints.toml
@@ -1,0 +1,19 @@
+[hints.transform.lapd_xy]
+pivot_to_center = "58.771"
+pivot_to_drive = "116.84"
+pivot_to_feedthru = "53.8"
+probe_axis_offset = "21.5"
+
+[hints.layer.grid]
+limits = "[[x_min, x_max], [y_min, y_max], ...]"
+npoints = "[Nx, Ny, ...]"
+
+[hints.layer.grid_CNStep]
+center = "[x_0, y_0, ...]"
+npoints = "[Nx, Ny, ...]"
+step_size = "[dx, dy, ...]"
+
+[hints.layer.grid_CNSize]
+center = "[x_0, y_0, ...]"
+npoints = "[Nx, Ny, ...]"
+size = "[Lx, Ly, ...]"

--- a/bapsf_motion/gui/configure/parameter_hints.toml
+++ b/bapsf_motion/gui/configure/parameter_hints.toml
@@ -4,6 +4,18 @@ pivot_to_drive = "116.84"
 pivot_to_feedthru = "53.8"
 probe_axis_offset = "21.5"
 
+[hints.exclusion.circle]
+radius = "5.0"
+center = "[0, 0]"
+exclude = "inside  # possible options outside or inside"
+
+[hints.exclusion.divider]
+mb = "[slope, intercept]  # use inf for vertical line"
+exclude = "-e0  # negative/left side of the line"
+
+[hints.exclusion.shadow]
+source_point = "[x, y]  # source of shadow caster"
+
 [hints.layer.grid]
 limits = "[[x_min, x_max], [y_min, y_max], ...]"
 npoints = "[Nx, Ny, ...]"

--- a/bapsf_motion/motion_builder/exclusions/lapd.py
+++ b/bapsf_motion/motion_builder/exclusions/lapd.py
@@ -161,7 +161,7 @@ class LaPDXYExclusion(GovernExclusion):
         diameter: float = 100,
         pivot_radius: float = 58.771,
         port_location: Union[str, float] = "E",
-        cone_full_angle: float = 80,
+        cone_full_angle: float = 58,
         include_cone: bool = True,
         skip_ds_add: bool = False,
     ):


### PR DESCRIPTION
This PR integrates the use of `QLineEdite.setPlaceholder` to create hints for key (layer, exclusion, and transform) input fields.  The text that populates these hints is stored in `parameter_hints.toml`.

The code is written such the hint is only added if it is defined in the TOML file, and ignored otherwise.

Now, when an input parameter for defining a layer, exclusion, or transform is blank the input field has a gray-ed out hint indicating what the input should look like.  This looks like ...

![image](https://github.com/user-attachments/assets/0723846d-f7df-45ad-88fc-4bacdd9fac7b)


---

- Created `bapsf_motion/gui/configure/parameter_hints.toml`.
- Created reading functionality for the hints TOML file `bapsf_motion.gui.configure.heleprs.read_parameter_hints()`
- Integrated hints into `MotionBuilderConfigOverlay`.
- Integrated hints into `TransformConfigOverlay`.