### PR TITLE
`LapdXYExclusion` set default `cone_full_angle` to 58 degrees

### DIFF
--- a/bapsf_motion/motion_builder/exclusions/lapd.py
+++ b/bapsf_motion/motion_builder/exclusions/lapd.py
@@ -161,7 +161,7 @@ class LaPDXYExclusion(GovernExclusion):
         diameter: float = 100,
         pivot_radius: float = 58.771,
         port_location: Union[str, float] = "E",
-        cone_full_angle: float = 80,
+        cone_full_angle: float = 58,
         include_cone: bool = True,
         skip_ds_add: bool = False,
     ):


### PR DESCRIPTION
Change the default value for the `cone_full_angle` kwarg of `LaPDXYExclusion` from 80 degrees to 58 degrees.  The ball valve itself has a full cone angle of 63 degrees (according to Marvin's Vellum files).