### PR TITLE
`MotionBuilderConfigOverlay`: Force a full canvas redraw when an exclusion is modified

### DIFF
--- a/bapsf_motion/gui/configure/motion_builder_overlay.py
+++ b/bapsf_motion/gui/configure/motion_builder_overlay.py
@@ -1049,6 +1049,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         # TODO: remove params_widget if the removed exclusion is currently
         #       populating the params_widget
 
+        self._mpl_canvas_full_draw = True
         self.configChanged.emit()
 
     @Slot()
@@ -1498,6 +1499,8 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
         else:
             self.mpl_canvas.update_motion_list()
 
+        self._mpl_canvas_full_draw = False
+
     def update_exclusion_list_box(self):
         self.logger.info("Updating Exclusion List Box")
         self.remove_ex_btn.setEnabled(False)
@@ -1548,10 +1551,12 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         if _registry is self.exclusion_registry and _name == "New Exclusion":
             self.mb.add_exclusion(_type, **_inputs)
+            self._mpl_canvas_full_draw = True
         elif _registry is self.exclusion_registry:
             # modifying existing exclusion
             self.mb.remove_exclusion(_name)
             self.mb.add_exclusion(_type, **_inputs)
+            self._mpl_canvas_full_draw = True
         elif _name == "New Layer":
             self.mb.add_layer(_type, **_inputs)
             self._mpl_canvas_full_draw = False
@@ -1647,6 +1652,7 @@ class MotionBuilderConfigOverlay(_ConfigOverlay):
 
         self._mb = MotionBuilder(**mb_config)
         self.mpl_canvas.link_motion_builder(self._mb)
+        self._mpl_canvas_full_draw = True
         self.configChanged.emit()
         return self._mb
 


### PR DESCRIPTION
I noticed the motion space plot was not being properly updated when an exclusion layer was modified during the `MotionBuilderConfigOverlay` session.  This was due to the `matplotlib` not being fully redrawn when the boolean mask was changed (i.e. exclusion layer modified).  This PR ensures `_mpl_canvas_full_draw` is set before every call to `configChanged.emit()`, which triggers the canvas redraw.  `_mpl_canvas_full_draw` is set `True` whenever an exclusion layer is modified.