### PR TITLE
Update `Motor`'s ability to move off a limit switch and integrate functionality ino the `ConfigureGUI`

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1712,6 +1712,12 @@ class Motor(EventActor):
         Start a continuous jog.  The motor will not stop until
         commanded to.
         """
+        if direction not in ["forward", "backward"]:
+            self.logger.error(
+                "ValueError: Argument `direction` value must be 'forward' or 'backward'."
+            )
+            return
+
         if self.status["alarm"]:
             self.send_command("alarm_reset")
             alarm_msg = self.retrieve_motor_alarm(defer_status_update=True)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1587,6 +1587,7 @@ class Motor(EventActor):
             self.logger.error(f"Motor returned alarm(s): {alarm_message}")
 
         alarm_status = {
+            "alarm": rtn != "0000",
             "alarm_message": alarm_message,
             "limits": {
                 "CCW": True if 2 in codes else False,

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -871,8 +871,8 @@ class Motor(EventActor):
         #       ip argument
         if self._motor["ip"] is not None:
             self.logger.warning(
-                "The motor's IP address can only be defined at object"
-                " instantiation."
+                "The motor's IP address can only be defined at object "
+                "instantiation."
             )
             return
 
@@ -1032,8 +1032,8 @@ class Motor(EventActor):
                 socket_ip, socket_port = self.socket.getpeername()
             except OSError as err:
                 self.logger.error(
-                    "Appears the socket is bad.  It was likely disconnected by"
-                    " the sever or the client.",
+                    "Appears the socket is bad.  It was likely disconnected by "
+                    "the sever or the client.",
                     exc_info=err,
                 )
             else:
@@ -1116,7 +1116,7 @@ class Motor(EventActor):
 
         except (ConnectionError, TimeoutError, OSError) as err:
             # Note: if the Ack/Nack protocol is not properly set (see method
-            #       read_and_set_protocol(), then TimeoutErrors can occur
+            #       read_and_set_protocol()), then TimeoutErrors can occur
             #       even if the connection is still established.
             #
             self.logger.error(
@@ -1328,7 +1328,7 @@ class Motor(EventActor):
             # command and motor buffer have come out of sync
             #
             # Note:  this will not be an infinite loop, if the buffer
-            #        size is zero and we missed the response, then
+            #        size is zero, and we missed the response, then
             #        self._recv will issue a TimeoutError
 
             recv = self._recv()
@@ -1916,8 +1916,8 @@ class Motor(EventActor):
             return
         elif ic == self.ack_flags.MALFORMED:
             self.logger.error(
-                "Unable to set current due to the motor response not matching"
-                " the expected response."
+                "Unable to set current due to the motor response not matching "
+                "the expected response."
             )
             return
         new_ic = np.min(
@@ -1961,8 +1961,8 @@ class Motor(EventActor):
             return
         elif curr == self.ack_flags.MALFORMED:
             self.logger.error(
-                "Unable to set idle current due to the motor response not"
-                " matching the expected response."
+                "Unable to set idle current due to the motor response not "
+                "matching the expected response."
             )
             return
         new_ic = percent * curr
@@ -2002,8 +2002,8 @@ class Motor(EventActor):
             return
         elif ic == self.ack_flags.MALFORMED:
             self.logger.error(
-                "Unable to confirm set position due to the motor response"
-                " not matching the expected response."
+                "Unable to confirm set position due to the motor response "
+                "not matching the expected response."
             )
             return
 
@@ -2013,8 +2013,8 @@ class Motor(EventActor):
             return
         elif curr == self.ack_flags.MALFORMED:
             self.logger.error(
-                "Unable to confirm set position due to motor response"
-                " not matching the expected response."
+                "Unable to confirm set position due to motor response "
+                "not matching the expected response."
             )
             return
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1805,6 +1805,7 @@ class Motor(EventActor):
 
         counts = 1
         on_limits = any(self.status["limits"].values())
+        switched_directions = False
         while on_limits:
 
             if counts > 10:
@@ -1838,8 +1839,17 @@ class Motor(EventActor):
 
             # reverse direction if motor did not move
             if np.isclose(self.position.value, pos):
+                if switched_directions:
+                    # off direction has already flipped once
+                    self.logger.warning(
+                        "Attempted to move off limit in both directions and "
+                        "was unsuccessful."
+                    )
+                    break
+
                 # no movement happened, try reversing direction
                 off_direction = -off_direction
+                switched_directions = True
 
             counts += 1
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -425,6 +425,9 @@ class AxisControlWidget(QWidget):
             self._update_display_of_axis_status
         )
 
+        self.limit_fwd_btn.clicked.connect(self._move_off_limit)
+        self.limit_bwd_btn.clicked.connect(self._move_off_limit)
+
         self.jog_forward_btn.clicked.connect(self.jog_forward)
         self.jog_backward_btn.clicked.connect(self.jog_backward)
         self.zero_btn.clicked.connect(self._zero_axis)
@@ -616,6 +619,14 @@ class AxisControlWidget(QWidget):
     @Slot()
     def _disable_motor(self):
         self.axis.send_command("disable")
+
+    @Slot()
+    def _move_off_limit(self):
+        axis = self.axis
+        if axis is None:
+            return
+
+        axis.motor.move_off_limit()
 
     def _move_to(self, target_ax_pos):
         target_pos = self.mg.position.value


### PR DESCRIPTION
This PR does...

1. Removes the blanket alarm code gatekeeping on `Motor.move_to` and `Motor.continuous_jog` so the motor can be move off a limit switch.  If the alarm is caused ONLY by a limit switch, then the functionality will try to move off the limit.  Any other alarm will still prevent movement.
2. Created method `Motor._moveable` so moveable status of a motor can be checked before attempting a move.
3. Updated/simplified `Motor.move_off_limit` to work better with the changes made to `Motor.move_to`.
   - The motor will move in half turns until it has successfully moved off the limit.
   - If the motor position does not change after an attempted move, then it will reverse direction.
5. Connected the forward and backward limit buttons on the `ConfigureGUI` (specifically `AxisControlWidget`) to `Motor.move_off_limit`.