### PR TITLE
Create class `MotorSignals`

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -180,13 +180,28 @@ class CommandEntry(UserDict):
 
 
 class MotorSignals:
-    r"""Class to define all the `SimpleSignal`\ 's used by `Motor`."""
+    r"""
+    Class that defines all the `SimpleSignal`\ 's used by `Motor`.
+    """
     def __init__(self):
-        self.status_changed = SimpleSignal()
-        self.movement_started = SimpleSignal()
-        self.movement_finished = SimpleSignal()
-        self.connection_lost = SimpleSignal()
-        self.connection_established = SimpleSignal()
+        self._status_changed = SimpleSignal()
+        self._movement_started = SimpleSignal()
+        self._movement_finished = SimpleSignal()
+
+    @property
+    def status_changed(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor `status` is changes."""
+        return self._status_changed
+
+    @property
+    def movement_started(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor movement is started."""
+        return self._movement_started
+
+    @property
+    def movement_finished(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor movement is completed."""
+        return self._movement_finished
 
 
 class Motor(EventActor):

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -179,6 +179,16 @@ class CommandEntry(UserDict):
         return self._command
 
 
+class MotorSignals:
+    r"""Class to define all the `SimpleSignal`\ 's used by `Motor`."""
+    def __init__(self):
+        self.status_changed = SimpleSignal()
+        self.movement_started = SimpleSignal()
+        self.movement_finished = SimpleSignal()
+        self.connection_lost = SimpleSignal()
+        self.connection_established = SimpleSignal()
+
+
 class Motor(EventActor):
     """
     An actor class for directly communicating to an ethernet based
@@ -568,9 +578,7 @@ class Motor(EventActor):
             self._motor["DEFAULTS"]["current"] = current
 
         # simple signal to tell handlers that _status changed
-        self.status_changed = SimpleSignal()
-        self.movement_started = SimpleSignal()
-        self.movement_finished = SimpleSignal()
+        self.signals = MotorSignals()
 
         self.ip = ip
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -593,7 +593,7 @@ class Motor(EventActor):
             self._motor["DEFAULTS"]["current"] = current
 
         # simple signal to tell handlers that _status changed
-        self.signals = MotorSignals()
+        self._signals = MotorSignals()
 
         self.ip = ip
 
@@ -737,6 +737,16 @@ class Motor(EventActor):
         motor.
         """
         return self._motor
+
+    @property
+    def signals(self) -> MotorSignals:
+        """
+        Collection of all the signals emitted by the `Motor` class.
+
+        See `MotorSignals` for additional documentation on the
+        individual signals.
+        """
+        return self._signals
 
     @property
     def _status_defaults(self) -> Dict[str, Any]:

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -776,16 +776,6 @@ class Motor(EventActor):
         # TODO: dictionary keys and explanations to the docstring
         return self._status
 
-    @property
-    def movement_started(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor movement is started."""
-        return self.signals.movement_started
-
-    @property
-    def movement_finished(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor movement is completed."""
-        return self.signals.movement_finished
-
     def _lost_connection(self, rtn: Any = None):
         """
         Check if the motor connection was lost by examining the return
@@ -1573,9 +1563,9 @@ class Motor(EventActor):
         if "moving" not in _status:
             pass
         elif _status["moving"] and not self._status["moving"]:
-            self.movement_started.emit()
+            self.signals.movement_started.emit()
         elif not _status["moving"] and self._status["moving"]:
-            self.movement_finished.emit()
+            self.signals.movement_finished.emit()
 
         self._update_status(**_status)
 
@@ -1705,8 +1695,8 @@ class Motor(EventActor):
 
         # disconnect all signals before terminating
         self.signals.status_changed.disconnect_all()
-        self.movement_started.disconnect_all()
-        self.movement_finished.disconnect_all()
+        self.signals.movement_started.disconnect_all()
+        self.signals.movement_finished.disconnect_all()
 
         if not self.terminated and self._status["connected"]:
             self.stop()

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -2,7 +2,7 @@
 Module for functionality focused around the
 `~bapsf_motion.actors.motor_.Motor` actor class.
 """
-__all__ = ["do_nothing", "CommandEntry", "Motor"]
+__all__ = ["do_nothing", "CommandEntry", "Motor", "MotorSignals"]
 __actors__ = ["Motor"]
 
 import asyncio

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -181,7 +181,8 @@ class CommandEntry(UserDict):
 
 class MotorSignals:
     r"""
-    Class that defines all the `SimpleSignal`\ 's used by `Motor`.
+    Class that defines all the `~bapsf_motion.utils.SimpleSignal`\ 's
+    used by `Motor`.
     """
     def __init__(self):
         self._status_changed = SimpleSignal()
@@ -190,17 +191,25 @@ class MotorSignals:
 
     @property
     def status_changed(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor `status` is changes."""
+        """
+        `~bapsf_motion.utils.SimpleSignal` emitted when the motor
+        `~Motor.status` is changes."""
         return self._status_changed
 
     @property
     def movement_started(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor movement is started."""
+        """
+        `~bapsf_motion.utils.SimpleSignal` emitted when the motor
+        movement is started.
+        """
         return self._movement_started
 
     @property
     def movement_finished(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor movement is completed."""
+        """
+        `~bapsf_motion.utils.SimpleSignal` emitted when the motor
+        movement is completed.
+        """
         return self._movement_finished
 
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -767,11 +767,6 @@ class Motor(EventActor):
         return self._status
 
     @property
-    def status_changed(self) -> SimpleSignal:
-        """`SimpleSignal` emitted when the motor `status` is changes."""
-        return self.signals.status_changed
-
-    @property
     def movement_started(self) -> SimpleSignal:
         """`SimpleSignal` emitted when the motor movement is started."""
         return self.signals.movement_started
@@ -1054,7 +1049,7 @@ class Motor(EventActor):
             return
 
         self._status = new_status
-        self.status_changed.emit()
+        self.signals.status_changed.emit()
 
     def connect(self):
         """
@@ -1699,7 +1694,7 @@ class Motor(EventActor):
         self.logger.info("Terminating motor")
 
         # disconnect all signals before terminating
-        self.status_changed.disconnect_all()
+        self.signals.status_changed.disconnect_all()
         self.movement_started.disconnect_all()
         self.movement_finished.disconnect_all()
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -751,6 +751,21 @@ class Motor(EventActor):
         # TODO: dictionary keys and explanations to the docstring
         return self._status
 
+    @property
+    def status_changed(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor `status` is changes."""
+        return self.signals.status_changed
+
+    @property
+    def movement_started(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor movement is started."""
+        return self.signals.movement_started
+
+    @property
+    def movement_finished(self) -> SimpleSignal:
+        """`SimpleSignal` emitted when the motor movement is completed."""
+        return self.signals.movement_finished
+
     def _lost_connection(self, rtn: Any = None):
         """
         Check if the motor connection was lost by examining the return

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -339,7 +339,7 @@ class AxisConfigWidget(QWidget):
                 auto_run=True,
             )
 
-            axis.motor.status_changed.connect(self._update_online_led)
+            axis.motor.signals.status_changed.connect(self._update_online_led)
         except ConnectionError:
             axis = None
 
@@ -399,7 +399,7 @@ class AxisConfigWidget(QWidget):
         if isinstance(self.axis, Axis):
             self.axis.terminate(delay_loop_stop=True)
 
-        axis.motor.status_changed.connect(self._update_online_led)
+        axis.motor.signals.status_changed.connect(self._update_online_led)
         self.axis = axis
 
     def set_ip_handler(self, handler: callable):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -728,8 +728,8 @@ class AxisControlWidget(QWidget):
         self._axis_index = ax_index
 
         self.axis_name_label.setText(self.axis.name)
-        self.axis.motor.status_changed.connect(self.update_display_of_axis_status)
-        self.axis.motor.status_changed.connect(self.axisStatusChanged.emit)
+        self.axis.motor.signals.status_changed.connect(self.update_display_of_axis_status)
+        self.axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
         self.axis.motor.movement_started.connect(self._emit_movement_started)
         self.axis.motor.movement_finished.connect(self._emit_movement_finished)
         self.axis.motor.movement_finished.connect(self.update_display_of_axis_status)
@@ -740,8 +740,8 @@ class AxisControlWidget(QWidget):
     def unlink_axis(self):
         if self.axis is not None:
             # self.axis.terminate(delay_loop_stop=True)
-            self.axis.motor.status_changed.disconnect(self.update_display_of_axis_status)
-            self.axis.motor.status_changed.connect(self.axisStatusChanged.emit)
+            self.axis.motor.signals.status_changed.disconnect(self.update_display_of_axis_status)
+            self.axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
             self.axis.motor.movement_started.connect(self._emit_movement_started)
             self.axis.motor.movement_finished.connect(self._emit_movement_finished)
             self.axis.motor.movement_finished.disconnect(
@@ -776,8 +776,8 @@ class AxisControlWidget(QWidget):
         self.logger.info("Closing AxisControlWidget")
 
         if isinstance(self.axis, Axis):
-            self.axis.motor.status_changed.disconnect(self.update_display_of_axis_status)
-            self.axis.motor.status_changed.disconnect(self.axisStatusChanged.emit)
+            self.axis.motor.signals.status_changed.disconnect(self.update_display_of_axis_status)
+            self.axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
             self.axis.motor.movement_started.disconnect(self._emit_movement_started)
             self.axis.motor.movement_finished.disconnect(self._emit_movement_finished)
             self.axis.motor.movement_finished.disconnect(

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -730,9 +730,9 @@ class AxisControlWidget(QWidget):
         self.axis_name_label.setText(self.axis.name)
         self.axis.motor.signals.status_changed.connect(self.update_display_of_axis_status)
         self.axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
-        self.axis.motor.movement_started.connect(self._emit_movement_started)
-        self.axis.motor.movement_finished.connect(self._emit_movement_finished)
-        self.axis.motor.movement_finished.connect(self.update_display_of_axis_status)
+        self.axis.motor.signals.movement_started.connect(self._emit_movement_started)
+        self.axis.motor.signals.movement_finished.connect(self._emit_movement_finished)
+        self.axis.motor.signals.movement_finished.connect(self.update_display_of_axis_status)
         self.update_display_of_axis_status()
 
         self.axisLinked.emit()
@@ -742,9 +742,9 @@ class AxisControlWidget(QWidget):
             # self.axis.terminate(delay_loop_stop=True)
             self.axis.motor.signals.status_changed.disconnect(self.update_display_of_axis_status)
             self.axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
-            self.axis.motor.movement_started.connect(self._emit_movement_started)
-            self.axis.motor.movement_finished.connect(self._emit_movement_finished)
-            self.axis.motor.movement_finished.disconnect(
+            self.axis.motor.signals.movement_started.connect(self._emit_movement_started)
+            self.axis.motor.signals.movement_finished.connect(self._emit_movement_finished)
+            self.axis.motor.signals.movement_finished.disconnect(
                 self.update_display_of_axis_status
             )
 
@@ -778,9 +778,9 @@ class AxisControlWidget(QWidget):
         if isinstance(self.axis, Axis):
             self.axis.motor.signals.status_changed.disconnect(self.update_display_of_axis_status)
             self.axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
-            self.axis.motor.movement_started.disconnect(self._emit_movement_started)
-            self.axis.motor.movement_finished.disconnect(self._emit_movement_finished)
-            self.axis.motor.movement_finished.disconnect(
+            self.axis.motor.signals.movement_started.disconnect(self._emit_movement_started)
+            self.axis.motor.signals.movement_finished.disconnect(self._emit_movement_finished)
+            self.axis.motor.signals.movement_finished.disconnect(
                 self.update_display_of_axis_status
             )
 

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -19,7 +19,7 @@ from astropy import units
 from collections import UserDict
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Callable, List, Optional, Union
 
 from bapsf_motion.utils import exceptions, toml
 from bapsf_motion.utils.units_ import units, counts, steps, rev
@@ -32,28 +32,46 @@ ipv4_pattern = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
 
 class SimpleSignal:
+    """
+    A very simple, rudimentary class for creating signals.
+    """
     _handlers = None
 
     @property
-    def handlers(self):
+    def handlers(self) -> Union[None, List[Callable]]:
+        """List of callbacks/handlers connect to the signal."""
         if self._handlers is None:
             self._handlers = []
         return self._handlers
 
-    def connect(self, func):
+    def connect(self, func: Callable):
+        """
+        Connect the callback/handler ``func`` to the signal.  The
+        callback should take no arguments.
+        """
+        if not callable(func):
+            return None
+
         if func not in self.handlers:
             self.handlers.append(func)
 
     def disconnect(self, func=None):
+        """
+        Disconnect the callback/handler ``func`` from the signal.
+        """
         try:
             self.handlers.remove(func)
         except ValueError:
             pass
 
     def disconnect_all(self):
+        """
+        Disconnect all callbacks/handlers for the signal.
+        """
         self._handlers = None
 
     def emit(self):
+        """Emit the signal, which executes all the connected handlers."""
         for handler in self.handlers:
             handler()
 


### PR DESCRIPTION
This PR creates and implements a `MotorSignals` class that is used to handle all the `SimpleSignals` utilized by the `Motor` class.   An instance of `MotorSignals` is available on the `Motor` class as the `Motor.signals` property.

---

- Creates `MotorSignals` class.
- Creates `Motor.signals` property, which is an instance of `MotorSignals`.
- Adds documentation to `SimpleSignal`.
- Refactors:
  - `Motor.status_update` -> `Motor.signals.status_update`
  - `Motor.movement_started` -> `Motor.signals.movement_started`
  - `Motor.movement_finished` -> `Motor.signals.movement_finished`