### PR TITLE
Add buffered key for motor commands

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1223,7 +1223,14 @@ class Motor(EventActor):
             meth = getattr(self, command)
             return meth(*args)
 
-        elif not self.loop.is_running():
+        if self.is_moving and self._commands[command]["buffered"]:
+            self.logger.warning(
+                f"Buffered commands ({command}) are disallowed while the "
+                f"motor is moving."
+            )
+            return self.ack_flags.NACK
+
+        if not self.loop.is_running():
             # event loop not running, just send commands directly
             return self._send_command(command, *args)
 


### PR DESCRIPTION
Add to the `CommandEntry` user dict the `"buffered"` key to indicate if the the command is an immediate command (`buffered = False`) or buffered command (`buffered = True`).  Buffered commands are put into a queue by the physical motor, whereas as an immediate command is executed immediately by the physical motor.

When a physical motor is moving a buffered command is not executed until the motion is complete.  Thus, `Motor.send_command` is modified to ONLY send immediate commands to the physical motor while the motor is moving.