### PR TITLE
Fix passing of `motor_settings` during re-run of `Axis`

### DIFF
--- a/bapsf_motion/actors/axis_.py
+++ b/bapsf_motion/actors/axis_.py
@@ -121,7 +121,10 @@ class Axis(EventActor):
         if self.terminated:
             # we are restarting
             self._terminated = False
-            self._spawn_motor(ip=self.config["ip"])
+            self._spawn_motor(
+                ip=self.config["ip"],
+                motor_settings=self.config["motor_settings"],
+            )
 
         super().run(auto_run=auto_run)
 


### PR DESCRIPTION
This PR fixes the passing of the `motor_settings` kwarg during a re-run of the `Axis` actor.

`Axis.run` was not passing `motor_settings` to `Axis._spawn_motor` when re-running itself.

The `motor_settings` kwarg is given a default value of `None` for `Axis._spawn_motor`.