### PR TITLE
Add connection `SimpleSignals` to `MotorSignals`

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1095,6 +1095,16 @@ class Motor(EventActor):
         if dict_equal(old_status, new_status):
             return
 
+        if (
+            "connected" in new_status
+            and (new_status["connected"] is not self.status["connected"])
+        ):
+            # connection status changed
+            if new_status["connected"]:
+                self.signals.connection_established.emit()
+            else:
+                self.signals.connection_lost.emit()
+
         self._status = new_status
         self.signals.status_changed.emit()
 


### PR DESCRIPTION
This PR adds two `SimpleSignal`'s to `MotorSignals`, and thus `Motor.signals` that are intended to indicate when a TCP connection is established (`MotorSingals.connection_established`) or lost (`MotorSignals.connection_list`).

`Motor._update_status` is modified to emit the appropriate signal when the connection status changes.

---

- Add signals to `MotorSignals`
  - `MotorSignals.connection_established` emitted when a TCP connection is established with the physical motor.
  - `MotorSignals.connection_lost` emitted when the TCP connection with the physical motor is lost.
  - Have `Motor._update_status` emit these signals every time the "connected" status is updated.
