### PR TITLE
[Patch] `drive.connected` in GUI interface

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1095,7 +1095,7 @@ class DriveBaseController(QWidget):
             acw.show()
 
         self.setEnabled(not self._mg.terminated)
-        if not all(self.mg.drive.connected):
+        if not self.mg.drive.connected:
             self.setEnabled(False)
         self._determine_mspace_drive_polarity()
 
@@ -1157,7 +1157,7 @@ class DriveBaseController(QWidget):
         if not isinstance(self.mg, MotionGroup) or not isinstance(self.mg.drive, Drive):
             return
 
-        if all(self.mg.drive.connected):
+        if self.mg.drive.connected:
             self.setEnabled(True)
 
     @Slot(int)


### PR DESCRIPTION
This PR patches #139.  #139 was mistakenly merged before pushing the commit the removes `all()` around instances of `Drive.connected`.

`Drive.connected` originally returned a list of bools indicating which axes are connected, but is was modified to only return a `bool` indicating if all axes are connected or not.