### PR TITLE
Additional GUI patches for the stabalize connection upgrade

### DIFF
--- a/bapsf_motion/actors/axis_.py
+++ b/bapsf_motion/actors/axis_.py
@@ -128,10 +128,8 @@ class Axis(EventActor):
 
         super().run(auto_run=auto_run)
 
-        if self.motor is None:
-            return
-
-        self.motor.run(auto_run=auto_run)
+        if isinstance(self.motor, Motor):
+            self.motor.run(auto_run=auto_run)
 
     def terminate(self, delay_loop_stop=False):
         self.motor.terminate(delay_loop_stop=True)

--- a/bapsf_motion/actors/axis_.py
+++ b/bapsf_motion/actors/axis_.py
@@ -136,6 +136,7 @@ class Axis(EventActor):
         super().terminate(delay_loop_stop=delay_loop_stop)
 
     def _spawn_motor(self, ip, motor_settings: Optional[dict] = None):
+        self.logger.debug("Spawning Motor")
         if isinstance(self.motor, Motor) and not self.terminated:
             self.motor.terminate(delay_loop_stop=True)
 

--- a/bapsf_motion/actors/drive_.py
+++ b/bapsf_motion/actors/drive_.py
@@ -279,7 +279,7 @@ class Drive(EventActor):
         return pos * self.axes[0].units
 
     def terminate(self, delay_loop_stop=False):
-        for ax in self._axes:
+        for ax in self.axes:
             ax.terminate(delay_loop_stop=True)
 
         super().terminate(delay_loop_stop=delay_loop_stop)

--- a/bapsf_motion/actors/motion_group_.py
+++ b/bapsf_motion/actors/motion_group_.py
@@ -778,10 +778,8 @@ class MotionGroup(EventActor):
     def run(self, auto_run=True):
         super().run(auto_run=auto_run)
 
-        if self.drive is None:
-            return
-
-        self.drive.run(auto_run=auto_run)
+        if isinstance(self.drive, Drive):
+            self.drive.run(auto_run=auto_run)
 
     def _spawn_drive(
         self, config: Dict[str, Any]

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -687,6 +687,7 @@ class Motor(EventActor):
         try:
             self.connect()
         except ConnectionError:
+            self.logger.warning("Unable initialize connection to motor.")
             return None
 
         self._configure_motor()
@@ -699,6 +700,7 @@ class Motor(EventActor):
         return None
 
     def run(self, auto_run=True):
+        self.logger.info(f"Running motor - async loop hass is {self.loop.__hash__()}")
 
         # if actor was terminated, actor is restarting
         self._terminated = False

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1154,8 +1154,9 @@ class Motor(EventActor):
 
                 socket.setdefaulttimeout(1)
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.settimeout(1)  # 1 second timeout
+                s.settimeout(0.1)  # 1 second timeout
                 s.connect((self.ip, self.port))
+                s.settimeout(1)
 
                 msg = "...SUCCESS!!!"
                 self.logger.info(msg)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -703,10 +703,11 @@ class Motor(EventActor):
         # if actor was terminated, actor is restarting
         self._terminated = False
 
+        heartbeat_task = self.heartbeat_task
         if (
-            self.heartbeat_task is None
-            or self.heartbeat_task.done()
-            or self.heartbeat_task.cancelled()
+            not isinstance(heartbeat_task, asyncio.Task)
+            or heartbeat_task.done()
+            or heartbeat_task.cancelled()
         ):
             self._configure_before_run()
             self._initialize_tasks()
@@ -1025,11 +1026,12 @@ class Motor(EventActor):
         Current position of the motor, in motor units
         `~bapsf_motion.utils.steps`.
         """
+        heartbeat_task = self.heartbeat_task
         if (
             self.loop.is_running()
-            and self.heartbeat_task is not None
-            and not self.heartbeat_task.done()
-            and not self.heartbeat_task.cancelled()
+            and isinstance(heartbeat_task, asyncio.Task)
+            and not heartbeat_task.done()
+            and not heartbeat_task.cancelled()
         ):
             # read from status if the heartbeat is operational
             return self.status["position"]
@@ -1054,16 +1056,16 @@ class Motor(EventActor):
     def heartbeat_task(self, val: asyncio.Task):
         if not isinstance(val, asyncio.Task):
             return
-        elif self.heartbeat_task is None:
+
+        heartbeat_task = self.heartbeat_task
+        if heartbeat_task is None:
             pass
-        elif self.heartbeat_task.done() or self.heartbeat_task.cancelled():
+        elif heartbeat_task.done() or heartbeat_task.cancelled():
             # remove task from task list
-            # self.tasks.remove(self.heartbeat_task)
-            self._heartbeat_task = []
+            self._heartbeat_task = None
         else:
             # val is a new task and heartbeat is still running...stop old heartbeat
-            self.loop.call_soon_threadsafe(self.heartbeat_task.cancel)
-            # self.tasks.remove(self._heartbeat_task)
+            self.loop.call_soon_threadsafe(heartbeat_task.cancel)
 
         self._heartbeat_task = [val]
         self.tasks.append(val)
@@ -1076,7 +1078,7 @@ class Motor(EventActor):
         except ValueError:
             pass
 
-        if self.heartbeat_task is None:
+        if not bool(self.heartbeat_task):
             return
 
         try:
@@ -1086,10 +1088,11 @@ class Motor(EventActor):
 
     def start_heartbeat(self):
         """Start or restart the heartbeat `asyncio.Task`."""
+        heartbeat_task = self.heartbeat_task
         if (
-            self.heartbeat_task is None
-            or self.heartbeat_task.done()
-            or self.heartbeat_task.cancelled()
+            not isinstance(heartbeat_task, asyncio.Task)
+            or heartbeat_task.done()
+            or heartbeat_task.cancelled()
         ):
             self.heartbeat_task = self.loop.create_task(self._heartbeat())
 
@@ -1190,10 +1193,11 @@ class Motor(EventActor):
         A low level method for sending commands to the motor, and
         receiving the response.
         """
+        heartbeat_task = self.heartbeat_task
         if self.loop.is_running() and (
-            self.heartbeat_task is None
-            or self.heartbeat_task.done()
-            or self.heartbeat_task.cancelled()
+            not isinstance(heartbeat_task, asyncio.Task)
+            or heartbeat_task.done()
+            or heartbeat_task.cancelled()
         ):
             self.start_heartbeat()
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -632,7 +632,8 @@ class Motor(EventActor):
         if isinstance(current, float) and 0.0 < current <= 1.0:
             self._motor["DEFAULTS"]["current"] = current
 
-        # simple signal to tell handlers that _status changed
+        # SimplgeSignal's to tell handlers about specific motor status
+        # changes
         self._signals = MotorSignals()
 
         self.ip = ip

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -636,8 +636,9 @@ class Motor(EventActor):
         # changes
         self._signals = MotorSignals()
 
+        # initialized attributes
+        self._n_connections_attempts = 0  # running total
         self.ip = ip
-
         self._pause_heartbeat = False
 
         try:
@@ -1145,8 +1146,11 @@ class Motor(EventActor):
         _allowed_attempts = self._setup["max_connection_attempts"]
         for _count in range(_allowed_attempts):
             try:
-                msg = f"Connecting to {self.ip}:{self.port} ..."
-                self.logger.info(msg)
+                self._n_connections_attempts += 1
+                self.logger.info(
+                    f"Connecting to {self.ip}:{self.port} "
+                    f"({self._n_connections_attempts})..."
+                )
 
                 socket.setdefaulttimeout(1)
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -703,15 +703,14 @@ class Motor(EventActor):
     def run(self, auto_run=True):
         self.logger.info(f"Running motor - async loop hass is {self.loop.__hash__()}")
 
-        # if actor was terminated, actor is restarting
-        self._terminated = False
-
         heartbeat_task = self.heartbeat_task
         if (
             not isinstance(heartbeat_task, asyncio.Task)
             or heartbeat_task.done()
             or heartbeat_task.cancelled()
         ):
+            # the actor is either starting or restarting
+            self._terminated = False
             self._configure_before_run()
             self._initialize_tasks()
 
@@ -1128,11 +1127,15 @@ class Motor(EventActor):
         reconnection attempts before an exception is raised is defined
         by ``self._setup["max_connection_attempts"]``.
         """
+        _lost_connection = self._lost_connection()
         if not isinstance(self.socket, socket.socket):
             # socket has not been created yet, self.socket is likely None
             pass
 
-        elif self._lost_connection():
+        elif self.socket.fileno() == -1:
+            # socket is closed
+            self.socket = None
+        elif _lost_connection:
             # connection to motor was lost, ensure the socket is closed before
             # trying to re-establish connection
             self.socket.shutdown(socket.SHUT_RDWR)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1158,8 +1158,7 @@ class Motor(EventActor):
                 s.connect((self.ip, self.port))
                 s.settimeout(1)
 
-                msg = "...SUCCESS!!!"
-                self.logger.info(msg)
+                self.logger.info("...SUCCESS!!!")
                 self.socket = s
                 self._update_status(connected=True)
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1791,6 +1791,7 @@ class Motor(EventActor):
 
         try:
             self.socket.close()
+            self._update_status(connected=False)
         except AttributeError:
             pass
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1750,7 +1750,7 @@ class DriveControlWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self._logger = gui_logger
+        self._logger = logging.getLogger(f"{gui_logger.name}.DCW")
 
         self._mg = None
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1928,6 +1928,8 @@ class DriveControlWidget(QWidget):
         return enabled and self.desktop_controller_widget.isEnabled()
 
     def link_motion_group(self, mg):
+        self.logger.debug("Linking motion group")
+
         if not isinstance(mg, MotionGroup):
             self.logger.warning(
                 f"Expected type {MotionGroup} for motion group, but got type"
@@ -3284,6 +3286,11 @@ class MGWidget(QWidget):
             #       so we are not explicitly setting the dropdown index here
 
         self._set_mg(mg)
+
+        if isinstance(mg, MotionGroup) and not mg.connected:
+            self.logger.info(
+                f"MotionGroup instantiated but could not connect to all motors."
+            )
 
         return mg
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1072,14 +1072,15 @@ class DriveBaseController(QWidget):
                 f" {type(mg)}."
             )
 
-        if mg.drive is None:
+        if not isinstance(mg.drive, Drive):
             # drive has not been set yet
             self.unlink_motion_group()
             return
-        elif (
-                self.mg is not None
-                and self.mg.drive is not None
-                and mg.drive is self.mg.drive
+
+        if (
+            isinstance(self.mg, MotionGroup)
+            and isinstance(self.mg.drive, Drive)
+            and mg.drive is self.mg.drive
         ):
             pass
         else:
@@ -1097,9 +1098,7 @@ class DriveBaseController(QWidget):
             acw.axisStatusChanged.connect(self.driveStatusChanged.emit)
             acw.show()
 
-        self.setEnabled(not self._mg.terminated)
-        if not self.mg.drive.connected:
-            self.setEnabled(False)
+        self.setEnabled(not (self._mg.terminated or not self._mg.connected))
         self._determine_mspace_drive_polarity()
 
     def unlink_motion_group(self):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1944,9 +1944,13 @@ class DriveControlWidget(QWidget):
             self.unlink_motion_group()
             self._mg = mg
 
-        self.setEnabled(not self._mg.terminated)
-        if not self.isEnabled():
+        if self._mg.terminated:
+            # MotionGroup is terminated so disabled controls and return
+            self.setEnabled(False)
             return
+
+        # Motion Group is operational, make controls operationsl
+        self.setEnabled(True)
 
         if isinstance(mg.mb, MotionBuilder):
             self.mspace_warning_dialog.display_dialog = False

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1755,7 +1755,6 @@ class DriveControlWidget(QWidget):
 
         self._mg = None
 
-        self.setEnabled(True)
         self.setFixedHeight(450)
 
         # Define BUTTONS
@@ -1804,6 +1803,7 @@ class DriveControlWidget(QWidget):
         _combo.setFixedWidth(175)
         self.controller_combo_box = _combo
 
+        self.setEnabled(True)
         self.setLayout(self._define_layout())
         self._connect_signals()
 
@@ -2005,6 +2005,14 @@ class DriveControlWidget(QWidget):
             return
 
         self.desktop_controller_widget.set_target_position(target_position)
+
+    def setDisabled(self, disable: bool):
+        self.lost_connection_dialog.setDisabled(disable)
+        super().setDisabled(disable)
+
+    def setEnabled(self, enable: bool):
+        self.lost_connection_dialog.setEnabled(enable)
+        super().setEnabled(enable)
 
     def closeEvent(self, event):
         self.logger.info(f"Closing {self.__class__.__name__}")

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -217,6 +217,9 @@ class LostConnectionMessageBox(QMessageBox):
         if not self.display_dialog:
             return True
 
+        if not self.isEnabled():
+            return True
+
         super().exec()
 
         return True

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1923,6 +1923,10 @@ class DriveControlWidget(QWidget):
     def _zero_drive(self):
         self.mg.set_zero()
 
+    def isEnabled(self) -> bool:
+        enabled = super().isEnabled()
+        return enabled and self.desktop_controller_widget.isEnabled()
+
     def link_motion_group(self, mg):
         if not isinstance(mg, MotionGroup):
             self.logger.warning(


### PR DESCRIPTION
more patching of #139 

Ensure the GUI behaves as expected when adding an unconnected drive.

When entering the `MGWidet` the GUI should:
- not crash
- not lock the user out from interacting with the GUI
- disabled any motor controls

---

- Replace conditionals the used the template `actor is None` with `not isinstance(actor, Actor)`
- add additional logging
- Fix `Motor.run` so a motor actor can be restarted after termination.
- Create `Motor._n_connection_attempts` to keep a running total of all connection attempts.
- Speed up `Motor.connect` by reducing the timeout to 100ms during the initial connection attempt, and then resetting the timeout to 1s.
- Created `DriveControlWidget.isEnabled()`, `DriveControlWidget.setDisabled()`, and `DriveControlWidget.setEnabled()`