### PR TITLE
Remove `pkg_resources` as a dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.10'
+    python: '3.13'
   apt_packages:
   - graphviz
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@
 import os
 import sys
 
-from pkg_resources import parse_version
 from datetime import datetime, timezone
+from packaging.version import Version
 from sphinx.application import Sphinx
 
 sys.path.insert(0, os.path.abspath("."))
@@ -190,10 +190,12 @@ copyright = f"2022–{datetime.now(timezone.utc).year}, {author}"
 #        However, release needs to be a semantic style version number, so set
 #        the 'unknown' case to ''.
 release = "" if release == "unknown" else release
-pv = parse_version(release)
-release = pv.public
+revision = ""
+if release != "":
+    pv = Version(release)
+    release = pv.public
+    revision = "" if pv.local is None else pv.local[1:]
 version = ".".join(release.split(".")[:2])  # short X.Y version
-revision = pv.local[1:] if pv.local is not None else ""
 
 # This is added to the end of RST files — a good place to put substitutions to
 # be used globally.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@
 import os
 import sys
 
-from datetime import datetime
 from pkg_resources import parse_version
+from datetime import datetime, timezone
 from sphinx.application import Sphinx
 
 sys.path.insert(0, os.path.abspath("."))
@@ -179,7 +179,7 @@ root_doc = "index"
 # General information about the project.
 project = "bapsf_motion"
 author = "BaPSF Community"
-copyright = f"2022–{datetime.utcnow().year}, {author}"
+copyright = f"2022–{datetime.now(timezone.utc).year}, {author}"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,6 +7,7 @@ ipython
 jinja2 >= 3.1.2
 nbsphinx >= 0.9.1
 numpydoc >= 1.5.0
+packaging
 pillow >= 9.5.0
 pygments >= 2.15.0
 sphinx >= 6.1.3, <= 7.3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ docs =
   jinja2 >= 3.1.2
   nbsphinx >= 0.9.1
   numpydoc >= 1.5.0
+  packaging
   pillow >= 9.5.0
   pygments >= 2.15.0
   sphinx >= 6.1.3, <= 7.3.7


### PR DESCRIPTION
This PR will remove the deprecated `pkg_resources` as a dependency.

---

- Have RTD build using Python 3.13
- Switch from using `pkg_resources.parse_version` to `packaging.version.Version`
- Add `packaging` as a documentation dependency.
- Stop using the deprecated functionality `datetime.utcnow()`, and replace with `datetime.now(timezone.utc)`