### PR TITLE
[PATCH] Game controller interface crash when moving and clicking connect

### DIFF
--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -244,7 +244,7 @@ class PyGameJoystickRunner(QRunnable):
         super().__init__()
 
         self._logger = gui_logger
-        self._axis_dead_zone = 0.1
+        self._axis_dead_zone = 0.25
         self._run_loop = False
 
         # Re-instantiate the joystick since the given joystick was probably

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -313,6 +313,11 @@ class PyGameJoystickRunner(QRunnable):
                     if np.abs(value) <= self.axis_dead_zone:
                         continue
 
+                    value2 = self.joystick.get_axis(jaxis)
+                    if np.abs(value2) - np.abs(value) < 0:
+                        # joystick is moving back towards the neutral position
+                        value = 0.0
+
                     self.signals.axisMoved.emit(jaxis, value)
 
                     # self.logger.info(

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -306,10 +306,10 @@ class PyGameJoystickRunner(QRunnable):
                     self.signals.hatPressed.emit(axis_id, direction)
 
                 elif event.type == pygame.JOYAXISMOTION:
-                    axis = event.dict["axis"]
+                    jaxis = event.dict["axis"]
                     value = event.dict["value"]
 
-                    self.signals.axisMoved.emit(axis, value)
+                    self.signals.axisMoved.emit(jaxis, value)
 
                     # self.logger.info(
                     #     f"PyGame event {event.type} - Data = {event.dict}."

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -233,6 +233,7 @@ class PyGameJoystickRunnerSignals(QObject):
     axisMoved = Signal(int, float)
     joystickConnected = Signal(bool)
     shutdownLoop = Signal()
+    stopMovement = Signal()
 
 
 class PyGameJoystickRunner(QRunnable):
@@ -322,6 +323,8 @@ class PyGameJoystickRunner(QRunnable):
 
     @Slot()
     def run_shutdown(self):
+        self.signals.stopMovement.emit()
+
         if self.run_loop:
             self.quit()
             self.signals.shutdownLoop.emit()
@@ -1618,6 +1621,7 @@ class DriveGameController(DriveBaseController):
             self._handle_button_press
         )
         self._pygame_joystick_runner.signals.hatPressed.connect(self._handle_hat_press)
+        self._pygame_joystick_runner.signals.stopMovement.connect(self.stop_move)
 
         self._thread_pool.start(self._pygame_joystick_runner)
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -311,7 +311,7 @@ class PyGameJoystickRunner(QRunnable):
                         continue
 
                     value2 = self.joystick.get_axis(jaxis)
-                    if np.abs(value2) - np.abs(value) < 0:
+                    if np.abs(value2) - np.abs(value) < -0.01:
                         # joystick is moving back towards the neutral position
                         value = 0.0
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -250,10 +250,7 @@ class PyGameJoystickRunner(QRunnable):
 
         # Re-instantiate the joystick since the given joystick was probably
         # instantiated in a different thread.
-        joystick.init()
-        js_id = joystick.get_id()
-        joystick.quit()
-        self._joystick = pygame.joystick.Joystick(js_id)
+        self._joystick = joystick
 
         self.signals.shutdownLoop.connect(self.run_shutdown)
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -310,6 +310,9 @@ class PyGameJoystickRunner(QRunnable):
                     jaxis = event.dict["axis"]
                     value = event.dict["value"]
 
+                    if np.abs(value) <= self.axis_dead_zone:
+                        continue
+
                     self.signals.axisMoved.emit(jaxis, value)
 
                     # self.logger.info(

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1636,6 +1636,9 @@ class DriveGameController(DriveBaseController):
 
     @Slot()
     def disconnect_controller(self):
+        if isinstance(self.mg, MotionGroup) and self.mg.is_moving:
+            self.stop_move()
+
         if self._pygame_joystick_runner is None:
             return
 
@@ -1644,7 +1647,7 @@ class DriveGameController(DriveBaseController):
         self._thread_pool.waitForDone(200)
         self._thread_pool.clear()
 
-        if self.mg.is_moving:
+        if isinstance(self.mg, MotionGroup) and self.mg.is_moving:
             self.stop_move()
 
     def stop_move(self, axis=None, soft=False):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1616,6 +1616,10 @@ class DriveGameController(DriveBaseController):
     @Slot()
     def connect_controller(self):
         self.logger.info("Connecting controller.")
+
+        if isinstance(self._pygame_joystick_runner, PyGameJoystickRunner):
+            self.disconnect_controller()
+
         self._pygame_joystick_runner = PyGameJoystickRunner(self.joystick)
 
         self._pygame_joystick_runner.signals.joystickConnected.connect(

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -22,7 +22,7 @@ from bapsf_motion.motion_builder import MotionBuilder
 # the matplotlib backend imports must happen after import matplotlib and PySide6
 mpl.use("qtagg")  # matplotlib's backend for Qt bindings
 from matplotlib import pyplot as plt  # noqa
-from matplotlib.backend_bases import DrawEvent, Event, MouseEvent, PickEvent  # noqa
+from matplotlib.backend_bases import DrawEvent, PickEvent  # noqa
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas  # noqa
 from matplotlib.backends.backend_qtagg import (  # noqa
     NavigationToolbar2QT as NavigationToolbar,

--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -3,7 +3,7 @@
 -r install.txt
 matplotlib
 packaging
-pygame
+pygame-ce >= 2.2
 PySide6 >= 6.5.0; python_version >= '3.10'
 PySide6 <= 6.3.1; python_version < '3.10'
 qtawesome

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ gui =
   # ought to mirror requirements/gui.txt
   matplotlib
   packaging
-  pygame
+  pygame-ce >= 2.2
   PySide6 >= 6.5.0; python_version >= '3.10'
   PySide6 <= 6.3.1; python_version < '3.10'
   qtawesome


### PR DESCRIPTION
This PR patches a bug where the game controller interface `DriveGameController` crashes when the drive is moving and the user clicks the connect button.  This is a serious bug, since the drive will continue moving when the interface is no longer functional.

---

- Switched dependency on `pygame` to `pygame-ce`.  `pygame-ce` is a fork of `pygame` and has more active development.

<br>

- Added a `stopMovement` signal to `PyGameJoystickRunner`.
- `PyGameJoystickRunner` will NOT emit a joystick movement unless it is out of the defined dead zone, `axis_dead_zone`.
- `PyGameJoystickRunner.axis_dead_zone` increased from 0.1 to 0.25.
- `PyGameJoystickRunner` if the joystick is returning to the neutral position, then a positional value of 0.0 is emitted instead of the actual joystick position.

<br> 

- `DriveGameController.connect_controller` will `disconnect_controller` (i.e. any instance of `PyGameJoystickRunner`) before trying to connect an new controller.  **This was causing the crash since the runner `PyGameJoystickRunner` was not being properly shutdown upon and new controller connect.**
- `DriveGameController.disconnect_controller` now will stop the motor movement before stopping the joystick runner, and, for redundancy, stop the motors again.
- `DriveGameController` will stop the motors when `PyGameJoystickRunner.stopMovement` emits.