### PR TITLE
Add exporting of Transform calculator parameters and import of Transform parameters into the Transform configuratin GUI

### DIFF
--- a/bapsf_motion/gui/calculators/bases.py
+++ b/bapsf_motion/gui/calculators/bases.py
@@ -77,6 +77,7 @@ class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
         self.centralWidget().setLayout(layout)
 
         self.reset_btn.clicked.connect(self._reset_parameters)
+        self.export_btn.clicked.connect(self.emit_export_parameters)
         self._connect_signals()
 
     @property
@@ -172,6 +173,11 @@ class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
 
     @abstractmethod
     def _init_widgets(self): ...
+
+    @Slot()
+    def emit_export_parameters(self):
+        parameters = self._collect_export_parameters()
+        self.exportParameters.emit(parameters)
 
     def closeEvent(self, event: QCloseEvent):
         self.closing.emit()

--- a/bapsf_motion/gui/calculators/bases.py
+++ b/bapsf_motion/gui/calculators/bases.py
@@ -94,6 +94,13 @@ class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
         return _stylesheet
 
     @abstractmethod
+    def _collect_export_parameters(self) -> dict:
+        return {
+            "calculator_family": self._CALCULATOR_FAMILY,
+            "calculator_type": self._CALCULATOR_TYPE,
+        }
+
+    @abstractmethod
     def _connect_signals(self): ...
 
     @abstractmethod

--- a/bapsf_motion/gui/calculators/bases.py
+++ b/bapsf_motion/gui/calculators/bases.py
@@ -33,6 +33,9 @@ class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
     _IMAGE_DIR = _IMAGES_PATH
     _IMAGE_NAME = NotImplemented  # type: str
 
+    _CALCULATOR_FAMILY = None  # type: str | None
+    _CALCULATOR_TYPE = None  # type: str | None
+
     def __init__(self, parent=None):
         super().__init__(parent)
 

--- a/bapsf_motion/gui/calculators/bases.py
+++ b/bapsf_motion/gui/calculators/bases.py
@@ -26,6 +26,7 @@ class QABCMainWindow(ABCMeta, type(QMainWindow)): ...
 
 class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
     closing = Signal()
+    exportParameters = Signal(object)
 
     _WINDOW_TITLE = NotImplemented  # type: str
     _WINDOW_MARGIN = 12

--- a/bapsf_motion/gui/calculators/bases.py
+++ b/bapsf_motion/gui/calculators/bases.py
@@ -62,6 +62,14 @@ class BaseCalculatorWindow(QMainWindow, ABC, metaclass=QABCMainWindow):
         _btn.move(p)
         self.reset_btn = _btn
 
+        _btn = StyleButton("Export Parameters", parent=self)
+        _btn.setFixedWidth(200)
+        _btn.setFixedHeight(36)
+        _btn.setPointSize(14)
+        p = self.geometry().topLeft() + QPoint(240, 20)
+        _btn.move(p)
+        self.export_btn = _btn
+
         # initialized widgets
         self._init_widgets()
 

--- a/bapsf_motion/gui/calculators/lapd_xy_transform.py
+++ b/bapsf_motion/gui/calculators/lapd_xy_transform.py
@@ -241,6 +241,15 @@ class LaPDXYTransformCalculator(BaseCalculatorWindow):
         """
         return _stylesheet
 
+    def _collect_export_parameters(self) -> dict:
+        params = {
+            **super()._collect_export_parameters(),
+            "pivot_to_center": self.pivot_to_center,
+            "pivot_to_drive": self.pivot_to_drive,
+            "pivot_to_feedthru": self.pivot_to_feedthru,
+        }
+        return params
+
     def convert_measure_2a_to_measure_2b(
         self, measure_2a: Optional[float] = None
     ) -> float:

--- a/bapsf_motion/gui/calculators/lapd_xy_transform.py
+++ b/bapsf_motion/gui/calculators/lapd_xy_transform.py
@@ -187,6 +187,9 @@ class LaPDXYTransformCalculator(BaseCalculatorWindow):
         p = self.geometry().topLeft() + QPoint(262, 512)
         self.reset_btn.move(p)
 
+        p = self.reset_btn.pos() + QPoint(self.reset_btn.width() + 12, 0)
+        self.export_btn.move(p)
+
         _btn = QRadioButton(parent=self)
         p = self.measure_2a_label.pos() + QPoint(self.measure_2a_label.width() + 6, 0)
         _btn.move(p)

--- a/bapsf_motion/gui/calculators/lapd_xy_transform.py
+++ b/bapsf_motion/gui/calculators/lapd_xy_transform.py
@@ -14,6 +14,9 @@ class LaPDXYTransformCalculator(BaseCalculatorWindow):
     _WINDOW_TITLE = "LaPD XY Transform Calculator"
     _IMAGE_NAME = "LaPDXYTransform_diagram.png"
 
+    _CALCULATOR_FAMILY = "transform"
+    _CALCULATOR_TYPE = "lapd_xy"
+
     _defaults = {  # all values in cm
         "measure_1": 54.2,
         "measure_2a": 58.0,

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -38,6 +38,7 @@ from bapsf_motion.gui.calculators import LaPDXYTransformCalculator
 from bapsf_motion.gui.configure.helpers import gui_logger, gui_logger_config_dict
 from bapsf_motion.gui.configure.message_boxes import WarningMessageBox
 from bapsf_motion.gui.configure.motion_group_widget import MGWidget
+from bapsf_motion.gui.configure.transform_overlay import TransformConfigOverlay
 from bapsf_motion.gui.icons import icon_name_dict
 from bapsf_motion.gui.widgets import (
     DiscardButton,
@@ -798,8 +799,72 @@ class ConfigureGUI(QMainWindow):
         _window.setObjectName("lapd_xy_calculator")
         _window.show()
         _window.activateWindow()
+        _window.exportParameters.connect(self._import_calculator_parameters)
 
         self._launched_windows["lapd_xy_calculator"] = _window
+
+    @Slot(object)
+    def _import_calculator_parameters(self, parameters: Dict[str, Any]):
+        if not isinstance(parameters, dict):
+            return
+
+        calc_family = parameters.pop("calculator_family", None)
+        calc_type = parameters.pop("calculator_type", None)
+
+        if calc_family != "transform":
+            warn_msg = (
+                "Can NOT import parameters from the calculator, since "
+                f"the calculator family ('{calc_family}') is unknown."
+            )
+            self.logger.warning(warn_msg)
+
+            dialog = WarningMessageBox(warn_msg, parent=self)
+            dialog.exec()
+            return
+
+        active_widget = self._stacked_widget.currentWidget()
+        if not isinstance(active_widget, MGWidget):
+            warn_msg = (
+                "Can NOT import parameters from the calculator, since "
+                f"the Transformation Configuration Overlay is NOT active."
+            )
+            self.logger.warning(warn_msg)
+
+            dialog = WarningMessageBox(warn_msg, parent=self)
+            dialog.exec()
+            return
+
+        active_overlay = active_widget._overlay_widget
+        if not isinstance(active_overlay, TransformConfigOverlay):
+            warn_msg = (
+                "Can NOT import parameters from the calculator, since "
+                f"the Transformation Configuration Overlay is NOT active."
+            )
+            self.logger.warning(warn_msg)
+
+            dialog = WarningMessageBox(warn_msg, parent=self)
+            dialog.exec()
+            return
+
+        overlay_transform_type = active_overlay.transform_type
+        if calc_type != overlay_transform_type:
+            warn_msg = (
+                "Can NOT import parameters from the calculator, since "
+                f"the calculator transform type ('{calc_type}') does NOT "
+                f"match the transfrom type ('{overlay_transform_type}') "
+                f"of the current configuration window."
+            )
+            self.logger.warning(warn_msg)
+
+            dialog = WarningMessageBox(warn_msg, parent=self)
+            dialog.exec()
+            return
+
+        transform_params = {
+            **active_overlay.transform_inputs,
+            **parameters,
+        }
+        active_overlay.importParameters.emit(transform_params)
 
     @Slot(str)
     def _launched_windows_closed(self, name: str):

--- a/bapsf_motion/gui/configure/configure_.py
+++ b/bapsf_motion/gui/configure/configure_.py
@@ -851,7 +851,7 @@ class ConfigureGUI(QMainWindow):
             warn_msg = (
                 "Can NOT import parameters from the calculator, since "
                 f"the calculator transform type ('{calc_type}') does NOT "
-                f"match the transfrom type ('{overlay_transform_type}') "
+                f"match the transform type ('{overlay_transform_type}') "
                 f"of the current configuration window."
             )
             self.logger.warning(warn_msg)

--- a/bapsf_motion/gui/configure/transform_overlay.py
+++ b/bapsf_motion/gui/configure/transform_overlay.py
@@ -10,7 +10,7 @@ import ast
 import inspect
 import math
 
-from PySide6.QtCore import QSize, Qt, Slot, Signal
+from PySide6.QtCore import QSize, Qt, Signal, Slot
 from PySide6.QtWidgets import (
     QComboBox,
     QGridLayout,

--- a/bapsf_motion/gui/configure/transform_overlay.py
+++ b/bapsf_motion/gui/configure/transform_overlay.py
@@ -10,7 +10,7 @@ import ast
 import inspect
 import math
 
-from PySide6.QtCore import QSize, Qt, Slot
+from PySide6.QtCore import QSize, Qt, Slot, Signal
 from PySide6.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -37,6 +37,8 @@ import qtawesome as qta  # noqa
 
 
 class TransformConfigOverlay(_ConfigOverlay):
+    importParameters = Signal(object)
+
     registry = transform_registry
 
     def __init__(self, mg: MotionGroup, parent: "mgw.MGWidget" = None):
@@ -91,6 +93,7 @@ class TransformConfigOverlay(_ConfigOverlay):
         super()._connect_signals()
 
         self.combo_widget.currentTextChanged.connect(self._refresh_params_widget)
+        self.importParameters.connect(self._import_params)
 
     def _define_layout(self):
 

--- a/bapsf_motion/gui/configure/transform_overlay.py
+++ b/bapsf_motion/gui/configure/transform_overlay.py
@@ -181,6 +181,7 @@ class TransformConfigOverlay(_ConfigOverlay):
             self._transform_inputs = {}
 
         _widget = QWidget(parent=self)
+        _widget.setObjectName("Parameters Widget")
 
         layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/bapsf_motion/gui/configure/transform_overlay.py
+++ b/bapsf_motion/gui/configure/transform_overlay.py
@@ -280,6 +280,33 @@ class TransformConfigOverlay(_ConfigOverlay):
         _widget.setLayout(layout)
         return _widget
 
+    @Slot(object)
+    def _import_params(self, params: dict):
+        _backup_params = self.transform_inputs.copy()
+
+        if not isinstance(params, dict):
+            return
+        params.pop("type", None)
+
+        param_widget = self.findChild(QWidget, "Parameters Widget")
+        if not isinstance(param_widget, QWidget):
+            return
+
+        for param_name, param_val in params.items():
+            _input = param_widget.findChild(QLineEditSpecialized, param_name)
+            if not isinstance(_input, QLineEditSpecialized):
+                continue
+
+            if param_val is None:
+                input_string = ""
+            elif isinstance(param_val, float):
+                input_string = f"{param_val:.4f}"
+            else:
+                input_string = f"{param_val}"
+
+            _input.setText(input_string)
+            self._update_transform_inputs(_input)
+
     @Slot(str)
     def _refresh_params_widget(self, tr_type):
         _widget = self._define_params_widget(tr_type)


### PR DESCRIPTION
The PR adds infrastructure that allows the Transform calculator to export its computed transform parameters, and allow the `ConfigureGUI` and `TransformConfigOverlay` import those parameters.

---

- Added `exportParameters` signal to `BaseCalculatorWindow` which contains the parameter payload (dict of computer parameters).
- Added `Export Parameters` button to the `BaseCalculatorWindow`.
- Added to `BaseCalculatorWindow` class attributes `_CALCULATOR_FAMILY` and `_CALCULATOR_TYPE`.
  - `_CALCULATOR_FAMILY` specifies what "family" the calculator is used for.  For example, `"transform"` indicates the calculator of for computing transform parameters.
  - `_CALCULATOR_TYPE` specifies what type / class in the family the calculator is used for.  For example, `"lapd_xy"` indicates the calculator is computing parameters for `LaPDXYTransform`.

<br>

- Added slot `_import_calculator_parameters` to `ConfigureGUI`.  This is attached to the `exportParameters` signal, does the validation of the received parameters, and passes the parameters to the  `TransformConfigOverlay` (if active).
- Added slot `_import_params` to `TransformConfigOverlay`, which receives a dictionary of kwargs for a given transform and injects them into the current configuration build. 

<br>

- Warning dialog popups will be generated if:
  - The `TransformConfigOverlay` is not active
  - The current transform configuration type does not match the calculator type.