### PR TITLE
Add Speed Configuration to `ConfigureGUI`

### DIFF
--- a/bapsf_motion/actors/motion_group_.py
+++ b/bapsf_motion/actors/motion_group_.py
@@ -812,7 +812,7 @@ class MotionGroup(EventActor):
             )
             self._drive = None
 
-        if self._drive.terminated or self.terminated:
+        if (isinstance(self._drive, Drive) and self._drive.terminated) or self.terminated:
             # 1. terminated self if the new drive is terminated
             # 2. terminate drive if self is already terminated (it's up
             #    to the caller to re-run the motion group)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -670,13 +670,6 @@ class Motor(EventActor):
         if isinstance(current, (float, int)) and 0.0 < current <= 1.0:
             self._motor["DEFAULTS"]["current"] = current
 
-        # condition speed
-        speed = self.set_speeds(speed, skip_setting=True)
-        if speed is None:
-            self._motor["speed"] = self._motor["DEFAULTS"]["speed"]
-        else:
-            self._motor["speed"] = speed
-
         # SimplgeSignal's to tell handlers about specific motor status
         # changes
         self._signals = MotorSignals()

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -528,6 +528,11 @@ class Motor(EventActor):
             two_way=True,
             units=u.steps,
         ),
+        "set_limit_mode": CommandEntry(
+            "set_limit_mode",
+            send="",
+            method_command=True,
+        ),
         "speed": CommandEntry(
             "speed",
             send="VE",
@@ -651,7 +656,16 @@ class Motor(EventActor):
         self._setup = self._setup_defaults.copy()
         self._motor = self._motor_defaults.copy()
         self._status = self._status_defaults.copy()
-        self._limit_mode = limit_mode
+
+        # condition limit_mode
+        limit_mode = self.set_limit_mode(limit_mode, skip_setting=True)
+        if limit_mode is None:
+            self._limit_mode = self.motor["define_limits"]
+        else:
+            self._limit_mode = limit_mode
+            self.motor["define_limits"] = limit_mode
+
+        # condition current
         if isinstance(current, (float, int)) and 0.0 < current <= 1.0:
             self._motor["DEFAULTS"]["current"] = current
 
@@ -688,31 +702,6 @@ class Motor(EventActor):
     def _configure_before_run(self):
         # actions to be done during object instantiation, but before
         # the asyncio event loop starts running.
-        if self._limit_mode is None:
-            self._limit_mode = self.motor["define_limits"]
-        elif not isinstance(self._limit_mode, int):
-            self.logger.warning(
-                "Assuming limit mode 1 for input argument 'limit_mode'.",
-                exc_info=TypeError(
-                    "Was expecting an int of value 1, 2, or 3 for input "
-                    f"argument 'limit_mode', got type "
-                    f"{type(self._limit_mode)} instead."
-                ),
-            )
-            self._limit_mode = self.motor["define_limits"]
-        elif self._limit_mode not in (1, 2, 3):
-            self.logger.warning(
-                "Assuming limit mode 1 for input argument 'limit_mode'.",
-                exc_info=ValueError(
-                    "Was expecting an int of value 1, 2, or 3 for input "
-                    f"argument 'limit_mode', got value "
-                    f"{self._limit_mode} instead."
-                ),
-            )
-            self._limit_mode = self.motor["define_limits"]
-        else:
-            self.motor["define_limits"] = self._limit_mode
-
         try:
             self.connect()
         except ConnectionError:
@@ -885,7 +874,7 @@ class Motor(EventActor):
         # input is closed (energized)
         # TODO: Replace with normal send_command when "define_limits" command
         #       is added to _commands dict
-        self.send_command("define_limits", self.motor["define_limits"])
+        self.set_limit_mode(self.motor["define_limits"])
 
         # set format of immediate commands to decimal
         self._send_raw_command("IFD")
@@ -2156,6 +2145,36 @@ class Motor(EventActor):
             return
         new_ic = percent * curr
         self.send_command("idle_current", new_ic)
+
+    def set_limit_mode(self, limit_mode: int, skip_setting: bool = False):
+        if not isinstance(limit_mode, int):
+            self.logger.warning(
+                "Limit mode not set / changed.",
+                exc_info=TypeError(
+                    "Was expecting an int of value 1, 2, or 3 for input "
+                    f"argument 'limit_mode', got type "
+                    f"{type(limit_mode)} instead."
+                ),
+            )
+            return
+
+        if limit_mode not in (1, 2, 3):
+            self.logger.warning(
+                "Limit mode not set / changed.",
+                exc_info=ValueError(
+                    "Was expecting an int of value 1, 2, or 3 for input "
+                    f"argument 'limit_mode', got value "
+                    f"{limit_mode} instead."
+                ),
+            )
+            return
+
+        if not skip_setting:
+            self.send_command("define_limits", limit_mode)
+            self._limit_mode = limit_mode
+            self.motor["define_limits"] = self._limit_mode
+
+        return limit_mode
 
     def reset_currents(self):
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -533,6 +533,11 @@ class Motor(EventActor):
             send="",
             method_command=True,
         ),
+        "set_speeds": CommandEntry(
+            "set_speeds",
+            send="",
+            method_command=True,
+        ),
         "speed": CommandEntry(
             "speed",
             send="VE",
@@ -669,10 +674,12 @@ class Motor(EventActor):
         if isinstance(current, (float, int)) and 0.0 < current <= 1.0:
             self._motor["DEFAULTS"]["current"] = current
 
-        if isinstance(speed, (float, int)) and 0.0 < speed <= 15.0:
-            self._motor["speed"] = float(speed)
-        else:
+        # condition speed
+        speed = self.set_speeds(speed, skip_setting=True)
+        if speed is None:
             self._motor["speed"] = self._motor["DEFAULTS"]["speed"]
+        else:
+            self._motor["speed"] = speed
 
         # SimplgeSignal's to tell handlers about specific motor status
         # changes
@@ -879,13 +886,11 @@ class Motor(EventActor):
         # set format of immediate commands to decimal
         self._send_raw_command("IFD")
 
-        # set a slower speed
+        # set  speed
         speed = self.motor["speed"]
         if isinstance(speed, u.Quantity):
             speed = float(speed.value)
-
-        self.send_command("speed", speed)
-        self.send_command("jog_speed", speed)
+        self.set_speeds(speed)
 
         # set currents
         self.send_command("set_current", self.motor["DEFAULTS"]["current"])
@@ -2175,6 +2180,52 @@ class Motor(EventActor):
             self.motor["define_limits"] = self._limit_mode
 
         return limit_mode
+
+    def set_speeds(self, speed: float | int, skip_setting: bool = False):
+        if not isinstance(speed, (float, int)):
+            self.logger.warning(
+                "Speed not set / changed.",
+                exc_info=TypeError(
+                    "Was expecting a positive float, non-zero for input argument "
+                    f"'speed', got type {type(speed)} instead."
+                ),
+            )
+            return
+
+        if isinstance(speed, int):
+            speed = float(speed)
+
+        if speed <= 0.0:
+            self.logger.warning(
+                "Speed not set / changed.",
+                exc_info=ValueError(
+                    "Was expecting a positive, non-zero float for input argument "
+                    f"'speed', got value {speed} instead."
+                ),
+            )
+            return
+
+        if speed > 80.0:
+            self.logger.warning(
+                "Speed not set / changed.",
+                exc_info=ValueError(
+                    "Was expecting a positive, non-zero float less than 80 "
+                    f"for input argument 'speed', got value {speed} instead."
+                ),
+            )
+            return
+
+        if not skip_setting:
+            self.send_command("speed", speed)
+            self.send_command("jog_speed", speed)
+
+            speed = self.send_command("speed")
+            self.motor["speed"] = speed
+
+        if isinstance(speed, u.Quantity):
+            speed = float(speed.value)
+
+        return speed
 
     def reset_currents(self):
         """

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -637,7 +637,8 @@ class Motor(EventActor):
         *,
         ip: str,
         limit_mode: int = None,
-        current: float = 0.8,
+        current: float | int = 0.8,
+        speed: float | int = 4.0,
         name: str = None,
         logger: logging.Logger = None,
         loop: asyncio.AbstractEventLoop = None,
@@ -651,8 +652,13 @@ class Motor(EventActor):
         self._motor = self._motor_defaults.copy()
         self._status = self._status_defaults.copy()
         self._limit_mode = limit_mode
-        if isinstance(current, float) and 0.0 < current <= 1.0:
+        if isinstance(current, (float, int)) and 0.0 < current <= 1.0:
             self._motor["DEFAULTS"]["current"] = current
+
+        if isinstance(speed, (float, int)) and 0.0 < speed <= 15.0:
+            self._motor["speed"] = float(speed)
+        else:
+            self._motor["speed"] = self._motor["DEFAULTS"]["speed"]
 
         # SimplgeSignal's to tell handlers about specific motor status
         # changes
@@ -789,7 +795,7 @@ class Motor(EventActor):
             "gearing": None,  # steps/rev
             "encoder_resolution": None,  # counts/rev
             "DEFAULTS": {
-                "speed": 12.5,
+                "speed": 4.0,
                 "accel": 25,
                 "decel": 25,
                 "idle_current": 0.3,  # 30% of current
@@ -885,8 +891,12 @@ class Motor(EventActor):
         self._send_raw_command("IFD")
 
         # set a slower speed
-        self.send_command("speed", 4.0)
-        self.send_command("jog_speed", 4.0)
+        speed = self.motor["speed"]
+        if isinstance(speed, u.Quantity):
+            speed = float(speed.value)
+
+        self.send_command("speed", speed)
+        self.send_command("jog_speed", speed)
 
         # set currents
         self.send_command("set_current", self.motor["DEFAULTS"]["current"])
@@ -990,11 +1000,17 @@ class Motor(EventActor):
 
     @property
     def config(self) -> Dict[str, Any]:
+        speed = self.motor["speed"]
+        if isinstance(speed, u.Quantity):
+            speed = speed.value
+        speed = float(speed)
+
         return {
             "name": self.name,
             "ip": self.ip,
             "limit_mode": self.motor["define_limits"],
             "current": self.motor["DEFAULTS"]["current"],
+            "speed": speed,
         }
 
     config.__doc__ = EventActor.config.__doc__

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -662,7 +662,7 @@ class Motor(EventActor):
         self._motor = self._motor_defaults.copy()
         self._status = self._status_defaults.copy()
 
-        # initialize attriubtes that will be conditioned in _configure_before_run()
+        # initialize attributes that will be conditioned in _configure_before_run()
         self._motor["define_limits"] = limit_mode
         self._motor["speed"] = speed
 

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -708,6 +708,8 @@ class Motor(EventActor):
 
         # condition speed
         speed = self.motor["speed"]
+        if isinstance(speed, u.Quantity):
+            speed = float(speed.value)
         speed = self.set_speeds(speed, skip_setting=True)
         if speed is None:
             speed = self.motor["DEFAULTS"]["speed"]

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -662,13 +662,9 @@ class Motor(EventActor):
         self._motor = self._motor_defaults.copy()
         self._status = self._status_defaults.copy()
 
-        # condition limit_mode
-        limit_mode = self.set_limit_mode(limit_mode, skip_setting=True)
-        if limit_mode is None:
-            self._limit_mode = self.motor["define_limits"]
-        else:
-            self._limit_mode = limit_mode
-            self.motor["define_limits"] = limit_mode
+        # initialize attriubtes that will be conditioned in _configure_before_run()
+        self._motor["define_limits"] = limit_mode
+        self._motor["speed"] = speed
 
         # condition current
         if isinstance(current, (float, int)) and 0.0 < current <= 1.0:
@@ -709,6 +705,21 @@ class Motor(EventActor):
     def _configure_before_run(self):
         # actions to be done during object instantiation, but before
         # the asyncio event loop starts running.
+        #
+        # condition limit_mode
+        limit_mode = self.motor["define_limits"]
+        limit_mode = self.set_limit_mode(limit_mode, skip_setting=True)
+        if limit_mode is None:
+            limit_mode = self.motor["DEFAULTS"]["define_limits"]
+        self._motor["define_limits"] = limit_mode
+
+        # condition speed
+        speed = self.motor["speed"]
+        speed = self.set_speeds(speed, skip_setting=True)
+        if speed is None:
+            speed = self.motor["DEFAULTS"]["speed"]
+        self._motor["speed"] = speed
+
         try:
             self.connect()
         except ConnectionError:
@@ -798,12 +809,13 @@ class Motor(EventActor):
                 "current": 0.8,  # 80% of max_current (4.0 amps)
                 "max_idle_current": 0.9,  # 90% of current
                 "max_current": 5.0,  # 5 amps
+                "define_limits": 1,  # 1 = energized, 2 = de-energized, 3 = None
             },
             "speed": None,
             "accel": None,
             "decel": None,
             "protocol_settings": None,
-            "define_limits": 1,  # 1 = energized, 2 = de-energized, 3 = None
+            "define_limits": None,
         }
 
     @property
@@ -2176,8 +2188,7 @@ class Motor(EventActor):
 
         if not skip_setting:
             self.send_command("define_limits", limit_mode)
-            self._limit_mode = limit_mode
-            self.motor["define_limits"] = self._limit_mode
+            self.motor["define_limits"] = limit_mode
 
         return limit_mode
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -471,21 +471,16 @@ class AxisConfigWidget(QWidget):
 
     @Slot()
     def _change_limit_mode(self):
-        new_limit_mode = self.limit_mode_slider.value()
-        limit_mode = self.axis_config["motor_settings"]["limit_mode"]
+        axis_config = self.axis_config.copy()
+        old_limit_mode = axis_config["motor_settings"].get("limit_mode", None)
 
-        if new_limit_mode == limit_mode:
-            # nothing changed
+        limit_mode = self.limit_mode_slider.value()
+
+        if old_limit_mode is not None and old_limit_mode == limit_mode:
+            # limit_mode did not change
             return
 
-        axis_config = self.axis_config.copy()
-        axis_config["motor_settings"]["limit_mode"] = new_limit_mode
-
-        if isinstance(self.axis, Axis):
-            self.axis.terminate(delay_loop_stop=True)
-            self.axis = None
-
-        self.axis_config = axis_config
+        self._set_limit_mode(limit_mode)
 
     @Slot()
     def _change_speed_from_slider(self):
@@ -637,6 +632,24 @@ class AxisConfigWidget(QWidget):
             self.axis = None
 
         axis_config["motor_settings"]["speed"] = speed
+        self.axis_config = axis_config
+
+    def _set_limit_mode(self, limit_mode: int):
+
+        if isinstance(self.axis, Axis) and isinstance(self.axis.motor, Motor):
+            self.axis.motor.send_command("set_limit_mode", limit_mode)
+
+            motor_limit_mode = self.axis.motor.config["limit_mode"]
+            if motor_limit_mode == limit_mode:
+                self.configChanged.emit()
+                return
+
+        if isinstance(self.axis, Axis):
+            self.axis.terminate(delay_loop_stop=True)
+            self.axis = None
+        
+        axis_config = self.axis_config.copy()
+        axis_config["motor_settings"]["limit_mode"] = limit_mode
         self.axis_config = axis_config
 
     def closeEvent(self, event):

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -147,10 +147,14 @@ class AxisConfigWidget(QWidget):
         return layout
 
     def _define_vdivider_layout(self):
+        divider = VLinePlain(parent=self)
+        divider.set_color(60, 60, 60)
+        divider.setLineWidth(2)
+
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addSpacing(8)
-        layout.addWidget(VLinePlain(parent=self))
+        layout.addWidget(divider)
         layout.addSpacing(8)
         return layout
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -135,20 +135,14 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(12)
         layout.addWidget(ip_label)
         layout.addWidget(self.ip_widget)
-        layout.addSpacing(8)
-        layout.addWidget(VLinePlain(parent=self))
-        layout.addSpacing(8)
+        layout.addLayout(self._define_vdivider_layout())
         layout.addWidget(self.cm_per_rev_widget)
         layout.addWidget(cm_per_rev_label)
-        layout.addSpacing(8)
-        layout.addWidget(VLinePlain(parent=self))
-        layout.addSpacing(8)
+        layout.addLayout(self._define_vdivider_layout())
         layout.addLayout(self._define_limit_mode_layout())
-        layout.addSpacing(8)
-        layout.addWidget(VLinePlain(parent=self))
+        layout.addLayout(self._define_vdivider_layout())
         layout.addStretch()
-        layout.addWidget(VLinePlain(parent=self))
-        layout.addSpacing(8)
+        layout.addLayout(self._define_vdivider_layout())
         layout.addLayout(self._define_online_indicator_layout())
         return layout
 
@@ -232,6 +226,14 @@ class AxisConfigWidget(QWidget):
         )
         layout.addStretch(1)
 
+        return layout
+
+    def _define_vdivider_layout(self):
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addSpacing(8)
+        layout.addWidget(VLinePlain(parent=self))
+        layout.addSpacing(8)
         return layout
 
     @property

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -88,6 +88,18 @@ class AxisConfigWidget(QWidget):
         _widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.cm_per_rev_widget = _widget
 
+        _widget = QLineEdit(parent=self)
+        font = _widget.font()
+        font.setPointSize(16)
+        _widget.setFont(font)
+        _widget.setFixedWidth(120)
+        _widget.setValidator(
+            QDoubleValidator(bottom=0.5, top=15.0, decimals=1)
+        )
+        _widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.speed_input = _widget
+
+        # Define ADVANCED WIDGETS
         _widget = QSlider(Qt.Orientation.Horizontal, parent=self)
         _widget.setMinimum(1)
         _widget.setMaximum(3)
@@ -99,7 +111,19 @@ class AxisConfigWidget(QWidget):
         _widget.setValue(1)
         self.limit_mode_slider = _widget
 
-        # Define ADVANCED WIDGETS
+        speed_validator = self.speed_input.validator()  # type: QDoubleValidator
+        min_tick = int(speed_validator.bottom() / 0.1)
+        max_tick = int(speed_validator.top() / 0.1)
+        _widget = QSlider(Qt.Orientation.Horizontal, parent=self)
+        _widget.setMinimum(min_tick)
+        _widget.setMaximum(max_tick)
+        _widget.setTickInterval(10)
+        _widget.setSingleStep(1)
+        _widget.setTickPosition(QSlider.TickPosition.TicksBothSides)
+        _widget.setFixedHeight(24)
+        _widget.setMinimumWidth(100)
+        _widget.setValue(0)
+        self.speed_slider = _widget
 
         self.setLayout(self._define_layout())
         self._connect_signals()
@@ -127,6 +151,8 @@ class AxisConfigWidget(QWidget):
         layout.addLayout(self._define_cm_per_rev_layout())
         layout.addLayout(self._define_vdivider_layout())
         layout.addLayout(self._define_limit_mode_layout())
+        layout.addLayout(self._define_vdivider_layout())
+        layout.addWidget(self._define_speed_input_widget())
         layout.addLayout(self._define_vdivider_layout())
         layout.addStretch()
         layout.addLayout(self._define_vdivider_layout())
@@ -236,6 +262,76 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(8)
         layout.addLayout(slider_layout)
         return layout
+
+    def _define_speed_input_widget(self):
+        speed_validator = self.speed_input.validator()  # type: QDoubleValidator
+        min_speed = speed_validator.bottom()
+        max_speed = speed_validator.top()
+
+        min_speed_label = QLabel(f"{min_speed:.1f}", parent=self)
+        font = min_speed_label.font()
+        font.setPointSize(12)
+        min_speed_label.setFont(font)
+        min_speed_label.setStyleSheet("margin: 0px;")
+
+        max_speed_label = QLabel(f"{max_speed:.1f}", parent=self)
+        font = max_speed_label.font()
+        font.setPointSize(12)
+        max_speed_label.setFont(font)
+        max_speed_label.setStyleSheet("margin: 0px;")
+
+        speed_label = QLabel(f"SPEED", parent=self)
+        font = speed_label.font()
+        font.setPointSize(10)
+        speed_label.setFont(font)
+        speed_label.setStyleSheet("margin: 0px;")
+
+        unit_label = QLabel(f"rev / s", parent=self)
+        font = unit_label.font()
+        font.setPointSize(12)
+        unit_label.setFont(font)
+        unit_label.setStyleSheet("margin: 0px;")
+
+        slider_number_layout = QHBoxLayout()
+        slider_number_layout.setContentsMargins(0, 0, 0, 0)
+        slider_number_layout.addWidget(
+            min_speed_label, alignment=Qt.AlignmentFlag.AlignLeft
+        )
+        slider_number_layout.addStretch(1)
+        slider_number_layout.addWidget(
+            max_speed_label, alignment=Qt.AlignmentFlag.AlignRight
+        )
+
+        slider_layout = QHBoxLayout()
+        slider_layout.setContentsMargins(0, 0, 0, 0)
+        slider_layout.addSpacing(4)
+        slider_layout.addWidget(self.speed_slider)
+        slider_layout.addSpacing(4)
+
+        input_layout = QHBoxLayout()
+        input_layout.setContentsMargins(0, 0, 0, 0)
+        input_layout.addWidget(self.speed_input)
+        input_layout.addWidget(
+            unit_label,
+            alignment=Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+        )
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(
+            speed_label,
+            alignment=Qt.AlignmentFlag.AlignCenter,
+        )
+        layout.addSpacing(-20)
+        layout.addLayout(slider_number_layout)
+        layout.addLayout(slider_layout)
+        layout.addLayout(input_layout)
+
+        widget = QWidget(parent=self)
+        widget.setLayout(layout)
+        widget.setStyleSheet("margin: 0px;")
+        widget.setMinimumWidth(150)
+        return widget
 
     def _define_online_indicator_layout(self):
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -30,7 +30,14 @@ from bapsf_motion.actors import Axis, Drive, MotionGroup, Motor
 from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.bases import _ConfigOverlay
 from bapsf_motion.gui.configure.helpers import gui_logger
-from bapsf_motion.gui.widgets import HLinePlain, IPv4Validator, LED, StyleButton, VLinePlain
+from bapsf_motion.gui.widgets import (
+    HLinePlain,
+    IPv4Validator,
+    LED,
+    StyleButton,
+    VLinePlain,
+    QDoublePinnedValidator,
+)
 from bapsf_motion.utils import _deepcopy_dict, dict_equal, ipv4_pattern, loop_safe_stop
 
 
@@ -99,7 +106,7 @@ class AxisConfigWidget(QWidget):
         _widget.setFont(font)
         _widget.setFixedWidth(120)
         _widget.setValidator(
-            QDoubleValidator(bottom=0.5, top=15.0, decimals=1)
+            QDoublePinnedValidator(bottom=0.5, top=15.0, decimals=1)
         )
         _widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.speed_input = _widget

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
 )
 from typing import Any, Callable, Dict, List, Union
 
-from bapsf_motion.actors import Axis, Drive, MotionGroup
+from bapsf_motion.actors import Axis, Drive, MotionGroup, Motor
 from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.bases import _ConfigOverlay
 from bapsf_motion.gui.configure.helpers import gui_logger
@@ -484,35 +484,35 @@ class AxisConfigWidget(QWidget):
 
     @Slot()
     def _change_speed_from_slider(self):
+        axis_config = self.axis_config.copy()
+        old_speed = axis_config["motor_settings"].get("speed", None)
+
         speed = 0.1 * self.speed_slider.value()
         speed = self._validate_speed(speed)
 
+        if old_speed is not None and old_speed == speed:
+            # speed did not change
+            return
+
         self.logger.info(f"--> Speed change by slider input: {speed} rev/s")
 
-        axis_config = self.axis_config.copy()
-        axis_config["motor_settings"]["speed"] = speed
-
-        if isinstance(self.axis, Axis):
-            self.axis.terminate(delay_loop_stop=True)
-            self.axis = None
-
-        self.axis_config = axis_config
+        self._set_motor_speed(speed)
 
     @Slot()
     def _change_speed_from_field(self):
+        axis_config = self.axis_config.copy()
+        old_speed = axis_config["motor_settings"].get("speed", None)
+
         speed = ast.literal_eval(self.speed_input.text())
         speed = self._validate_speed(speed)
 
+        if old_speed is not None and old_speed == speed:
+            # speed did not change
+            return
+
         self.logger.info(f"--> Speed change by field input: {speed} rev/s")
 
-        axis_config = self.axis_config.copy()
-        axis_config["motor_settings"]["speed"] = speed
-
-        if isinstance(self.axis, Axis):
-            self.axis.terminate(delay_loop_stop=True)
-            self.axis = None
-
-        self.axis_config = axis_config
+        self._set_motor_speed(speed)
 
     def _validate_speed(self, speed: float) -> float:
         speed_validator = self.speed_input.validator()  # type: QDoubleValidator
@@ -607,6 +607,32 @@ class AxisConfigWidget(QWidget):
 
     def set_ip_handler(self, handler: callable):
         self._ip_handlers.append(handler)
+
+    def _set_motor_speed(self, speed: float | int):
+
+        axis_config = self.axis_config.copy()
+
+        if isinstance(self.axis, Axis) and isinstance(self.axis.motor, Motor):
+            self.axis.motor.send_command("speed", speed)
+            self.axis.motor.send_command("jog_speed", speed)
+            self.axis.motor._get_motor_parameters()
+
+            motor_speed = float(self.axis.motor.motor["speed"].value)
+            if motor_speed == speed:
+                self.configChanged.emit()
+                return
+            else:
+                axis_config = self.axis_config.copy()
+
+            self.axis.terminate(delay_loop_stop=True)
+            self.axis = None
+
+        if isinstance(self.axis, Axis):
+            self.axis.terminate(delay_loop_stop=True)
+            self.axis = None
+
+        axis_config["motor_settings"]["speed"] = speed
+        self.axis_config = axis_config
 
     def closeEvent(self, event):
         self.logger.info("Closing AxisConfigWidget")

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -34,9 +34,9 @@ from bapsf_motion.gui.widgets import (
     HLinePlain,
     IPv4Validator,
     LED,
+    QDoublePinnedValidator,
     StyleButton,
     VLinePlain,
-    QDoublePinnedValidator,
 )
 from bapsf_motion.utils import _deepcopy_dict, dict_equal, ipv4_pattern, loop_safe_stop
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -5,6 +5,7 @@ configuration overlay portion of the configuration GUI.
 
 __all__ = ["AxisConfigWidget", "DriveConfigOverlay"]
 
+import ast
 import asyncio
 import logging
 import warnings
@@ -48,7 +49,11 @@ class AxisConfigWidget(QWidget):
             "units": "cm",
             "ip": "",
             "units_per_rev": "",
-            "motor_settings": {"limit_mode": 1},
+            "motor_settings": {
+                "current": 0.8,
+                "limit_mode": 1,
+                "speed": 4.0,
+            },
         }
         self._axis = None
 
@@ -132,11 +137,14 @@ class AxisConfigWidget(QWidget):
         self.ip_widget.editingFinished.connect(self._change_ip_address)
         self.cm_per_rev_widget.editingFinished.connect(self._change_cm_per_rev)
         self.limit_mode_slider.valueChanged.connect(self._change_limit_mode)
+        self.speed_input.editingFinished.connect(self._change_speed_from_field)
+        self.speed_slider.valueChanged.connect(self._change_speed_from_slider)
 
         self.configChanged.connect(self._update_ip_widget)
         self.configChanged.connect(self._update_cm_per_rev_widget)
         self.configChanged.connect(self._update_online_led)
         self.configChanged.connect(self._update_limit_mode_widget)
+        self.configChanged.connect(self._update_speed_widgets)
 
     def _define_layout(self):
         layout = QHBoxLayout()
@@ -474,6 +482,51 @@ class AxisConfigWidget(QWidget):
 
         self.axis_config = axis_config
 
+    @Slot()
+    def _change_speed_from_slider(self):
+        speed = 0.1 * self.speed_slider.value()
+        speed = self._validate_speed(speed)
+
+        self.logger.info(f"--> Speed change by slider input: {speed} rev/s")
+
+        axis_config = self.axis_config.copy()
+        axis_config["motor_settings"]["speed"] = speed
+
+        if isinstance(self.axis, Axis):
+            self.axis.terminate(delay_loop_stop=True)
+            self.axis = None
+
+        self.axis_config = axis_config
+
+    @Slot()
+    def _change_speed_from_field(self):
+        speed = ast.literal_eval(self.speed_input.text())
+        speed = self._validate_speed(speed)
+
+        self.logger.info(f"--> Speed change by field input: {speed} rev/s")
+
+        axis_config = self.axis_config.copy()
+        axis_config["motor_settings"]["speed"] = speed
+
+        if isinstance(self.axis, Axis):
+            self.axis.terminate(delay_loop_stop=True)
+            self.axis = None
+
+        self.axis_config = axis_config
+
+    def _validate_speed(self, speed: float) -> float:
+        speed_validator = self.speed_input.validator()  # type: QDoubleValidator
+        min_speed = speed_validator.bottom()
+        max_speed = speed_validator.top()
+
+        speed = round(speed, 1)
+        if speed < min_speed:
+            speed = min_speed
+        elif speed > max_speed:
+            speed = max_speed
+
+        return speed
+
     def _spawn_axis(self) -> Union[Axis, None]:
         self.logger.info("Spawning Axis.")
         if isinstance(self.axis, Axis):
@@ -519,6 +572,22 @@ class AxisConfigWidget(QWidget):
     def _update_limit_mode_widget(self):
         limit_mode = self.axis_config["motor_settings"]["limit_mode"]
         self.limit_mode_slider.setValue(limit_mode)
+
+    @Slot()
+    def _update_speed_widgets(self):
+        speed = self.axis_config["motor_settings"].get("speed", 4.0)
+        slider_value = int(speed / 0.1)
+
+        self.logger.info(f"--> Updating speed widgets {speed} {slider_value}")
+
+        self.speed_input.blockSignals(True)
+        self.speed_slider.blockSignals(True)
+
+        self.speed_input.setText(f"{speed:.1f}")
+        self.speed_slider.setValue(slider_value)
+
+        self.speed_input.blockSignals(False)
+        self.speed_slider.blockSignals(False)
 
     def _validate_ip(self, ip):
         if ip == self.axis_config["ip"]:

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -131,7 +131,11 @@ class AxisConfigWidget(QWidget):
         cm_per_rev_label = _label
 
         layout = QHBoxLayout()
-        layout.addWidget(self.ax_name_widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(
+            self.ax_name_widget,
+            alignment=Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+        )
         layout.addSpacing(12)
         layout.addWidget(ip_label)
         layout.addWidget(self.ip_widget)

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -29,7 +29,7 @@ from bapsf_motion.actors import Axis, Drive, MotionGroup
 from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.bases import _ConfigOverlay
 from bapsf_motion.gui.configure.helpers import gui_logger
-from bapsf_motion.gui.widgets import HLinePlain, IPv4Validator, LED, StyleButton
+from bapsf_motion.gui.widgets import HLinePlain, IPv4Validator, LED, StyleButton, VLinePlain
 from bapsf_motion.utils import _deepcopy_dict, dict_equal, ipv4_pattern, loop_safe_stop
 
 
@@ -147,13 +147,21 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(12)
         layout.addWidget(ip_label)
         layout.addWidget(self.ip_widget)
-        layout.addSpacing(28)
+        layout.addSpacing(8)
+        layout.addWidget(VLinePlain(parent=self))
+        layout.addSpacing(8)
         layout.addWidget(self.cm_per_rev_widget)
         layout.addWidget(cm_per_rev_label)
-        layout.addSpacing(28)
+        layout.addSpacing(8)
+        layout.addWidget(VLinePlain(parent=self))
+        layout.addSpacing(8)
         layout.addLayout(self._define_limit_mode_layout())
+        layout.addSpacing(8)
+        layout.addWidget(VLinePlain(parent=self))
         layout.addStretch()
         layout.addLayout(sub_layout)
+        layout.addWidget(VLinePlain(parent=self))
+        layout.addSpacing(8)
         return layout
 
     def _define_limit_mode_layout(self):

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -130,18 +130,6 @@ class AxisConfigWidget(QWidget):
         _label.setFont(font)
         cm_per_rev_label = _label
 
-        _label = QLabel("online", parent=self)
-        _label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignCenter)
-        _label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        font = _label.font()
-        font.setPointSize(12)
-        _label.setFont(font)
-        online_label = _label
-
-        sub_layout = QVBoxLayout()
-        sub_layout.addWidget(online_label, alignment=Qt.AlignmentFlag.AlignBottom)
-        sub_layout.addWidget(self.online_led, alignment=Qt.AlignmentFlag.AlignCenter)
-
         layout = QHBoxLayout()
         layout.addWidget(self.ax_name_widget)
         layout.addSpacing(12)
@@ -159,9 +147,9 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(8)
         layout.addWidget(VLinePlain(parent=self))
         layout.addStretch()
-        layout.addLayout(sub_layout)
         layout.addWidget(VLinePlain(parent=self))
         layout.addSpacing(8)
+        layout.addLayout(self._define_online_indicator_layout())
         return layout
 
     def _define_limit_mode_layout(self):
@@ -220,6 +208,29 @@ class AxisConfigWidget(QWidget):
         layout.addWidget(_energized_label, 0, 1, 1, 3)
         layout.addWidget(_deenergized_label, 2, 4, 1, 3)
         layout.addWidget(_none_label, 0, 7, 1, 3)
+
+        return layout
+
+    def _define_online_indicator_layout(self):
+
+        _label = QLabel("Online?", parent=self)
+        font = _label.font()
+        font.setPointSize(12)
+        _label.setFont(font)
+        online_label = _label
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addStretch(1)
+        layout.addWidget(
+            online_label,
+            alignment=Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter,
+        )
+        layout.addWidget(
+            self.online_led,
+            alignment=Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter,
+        )
+        layout.addStretch(1)
 
         return layout
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -85,6 +85,7 @@ class AxisConfigWidget(QWidget):
         _widget.setFont(font)
         _widget.setFixedWidth(120)
         _widget.setValidator(QDoubleValidator(decimals=4))
+        _widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.cm_per_rev_widget = _widget
 
         _widget = QSlider(Qt.Orientation.Horizontal, parent=self)
@@ -114,22 +115,6 @@ class AxisConfigWidget(QWidget):
         self.configChanged.connect(self._update_limit_mode_widget)
 
     def _define_layout(self):
-        _label = QLabel("IP:  ", parent=self)
-        _label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
-        _label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        font = _label.font()
-        font.setPointSize(16)
-        _label.setFont(font)
-        ip_label = _label
-
-        _label = QLabel("cm / rev", parent=self)
-        _label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
-        _label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        font = _label.font()
-        font.setPointSize(16)
-        _label.setFont(font)
-        cm_per_rev_label = _label
-
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(
@@ -139,8 +124,7 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(12)
         layout.addLayout(self._define_ip_input_layout())
         layout.addLayout(self._define_vdivider_layout())
-        layout.addWidget(self.cm_per_rev_widget)
-        layout.addWidget(cm_per_rev_label)
+        layout.addLayout(self._define_cm_per_rev_layout())
         layout.addLayout(self._define_vdivider_layout())
         layout.addLayout(self._define_limit_mode_layout())
         layout.addLayout(self._define_vdivider_layout())
@@ -179,6 +163,29 @@ class AxisConfigWidget(QWidget):
             self.ip_widget,
             alignment=Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
         )
+        return layout
+
+    def _define_cm_per_rev_layout(self):
+        _label = QLabel("cm / rev", parent=self)
+        font = _label.font()
+        font.setPointSize(12)
+        _label.setFont(font)
+        _label.setContentsMargins(0, 0, 0, 0)
+        cm_per_rev_label = _label
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addStretch(1)
+        layout.addWidget(
+            self.cm_per_rev_widget,
+            alignment=Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter,
+        )
+        layout.addSpacing(-8)
+        layout.addWidget(
+            cm_per_rev_label,
+            alignment=Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter,
+        )
+        layout.addStretch(1)
         return layout
 
     def _define_limit_mode_layout(self):
@@ -735,6 +742,7 @@ class DriveConfigOverlay(_ConfigOverlay):
                 border: 2px solid rgb(60, 60, 60);
                 border-radius: 5px;
                 padding: 6px;
+                margine: 0px;
             }
             """)
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -146,6 +146,14 @@ class AxisConfigWidget(QWidget):
         layout.addLayout(self._define_online_indicator_layout())
         return layout
 
+    def _define_vdivider_layout(self):
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addSpacing(8)
+        layout.addWidget(VLinePlain(parent=self))
+        layout.addSpacing(8)
+        return layout
+
     def _define_limit_mode_layout(self):
         layout = QGridLayout()
 
@@ -226,14 +234,6 @@ class AxisConfigWidget(QWidget):
         )
         layout.addStretch(1)
 
-        return layout
-
-    def _define_vdivider_layout(self):
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addSpacing(8)
-        layout.addWidget(VLinePlain(parent=self))
-        layout.addSpacing(8)
         return layout
 
     @property

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -494,8 +494,6 @@ class AxisConfigWidget(QWidget):
             # speed did not change
             return
 
-        self.logger.info(f"--> Speed change by slider input: {speed} rev/s")
-
         self._set_motor_speed(speed)
 
     @Slot()
@@ -509,8 +507,6 @@ class AxisConfigWidget(QWidget):
         if old_speed is not None and old_speed == speed:
             # speed did not change
             return
-
-        self.logger.info(f"--> Speed change by field input: {speed} rev/s")
 
         self._set_motor_speed(speed)
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -105,9 +105,7 @@ class AxisConfigWidget(QWidget):
         font.setPointSize(16)
         _widget.setFont(font)
         _widget.setFixedWidth(120)
-        _widget.setValidator(
-            QDoublePinnedValidator(bottom=0.5, top=15.0, decimals=1)
-        )
+        _widget.setValidator(QDoublePinnedValidator(bottom=0.5, top=15.0, decimals=1))
         _widget.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.speed_input = _widget
 

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -610,27 +610,19 @@ class AxisConfigWidget(QWidget):
 
     def _set_motor_speed(self, speed: float | int):
 
-        axis_config = self.axis_config.copy()
-
         if isinstance(self.axis, Axis) and isinstance(self.axis.motor, Motor):
-            self.axis.motor.send_command("speed", speed)
-            self.axis.motor.send_command("jog_speed", speed)
-            self.axis.motor._get_motor_parameters()
+            self.axis.motor.send_command("set_speeds", speed)
 
-            motor_speed = float(self.axis.motor.motor["speed"].value)
+            motor_speed = float(self.axis.motor.config["speed"])
             if motor_speed == speed:
                 self.configChanged.emit()
                 return
-            else:
-                axis_config = self.axis_config.copy()
-
-            self.axis.terminate(delay_loop_stop=True)
-            self.axis = None
 
         if isinstance(self.axis, Axis):
             self.axis.terminate(delay_loop_stop=True)
             self.axis = None
 
+        axis_config = self.axis_config.copy()
         axis_config["motor_settings"]["speed"] = speed
         self.axis_config = axis_config
 
@@ -647,7 +639,7 @@ class AxisConfigWidget(QWidget):
         if isinstance(self.axis, Axis):
             self.axis.terminate(delay_loop_stop=True)
             self.axis = None
-        
+
         axis_config = self.axis_config.copy()
         axis_config["motor_settings"]["limit_mode"] = limit_mode
         self.axis_config = axis_config

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -189,10 +189,8 @@ class AxisConfigWidget(QWidget):
         return layout
 
     def _define_limit_mode_layout(self):
-        layout = QGridLayout()
-
         _label = QLabel("Limit\nMode", parent=self)
-        _label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignRight)
+        _label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignCenter)
         _label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         font = _label.font()
         font.setPointSize(16)
@@ -202,10 +200,6 @@ class AxisConfigWidget(QWidget):
         _energized_label.setAlignment(
             Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter
         )
-        # _energized_label.setMinimumWidth(24)
-        # _energized_label.setSizePolicy(
-        #     QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        # )
         font = _energized_label.font()
         font.setPointSize(12)
         _energized_label.setFont(font)
@@ -214,10 +208,6 @@ class AxisConfigWidget(QWidget):
         _deenergized_label.setAlignment(
             Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter
         )
-        # _deenergized_label.setMinimumWidth(24)
-        # _deenergized_label.setSizePolicy(
-        #     QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-        # )
         font = _deenergized_label.font()
         font.setPointSize(12)
         _deenergized_label.setFont(font)
@@ -226,25 +216,25 @@ class AxisConfigWidget(QWidget):
         _none_label.setAlignment(
             Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter
         )
-        # _none_label.setMinimumWidth(24)
-        # _none_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         font = _none_label.font()
         font.setPointSize(12)
         _none_label.setFont(font)
 
+        slider_layout = QGridLayout()
+        slider_layout.setContentsMargins(0, 0, 0, 0)
+        slider_layout.addWidget(self.limit_mode_slider, 1, 2, 1, 7)
+        slider_layout.addWidget(_energized_label, 0, 1, 1, 3)
+        slider_layout.addWidget(_deenergized_label, 2, 4, 1, 3)
+        slider_layout.addWidget(_none_label, 0, 7, 1, 3)
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(
             _label,
-            0,
-            0,
-            3,
-            1,
-            alignment=Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter,
+            alignment=Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter,
         )
-        layout.addWidget(self.limit_mode_slider, 1, 2, 1, 7)
-        layout.addWidget(_energized_label, 0, 1, 1, 3)
-        layout.addWidget(_deenergized_label, 2, 4, 1, 3)
-        layout.addWidget(_none_label, 0, 7, 1, 3)
-
+        layout.addSpacing(8)
+        layout.addLayout(slider_layout)
         return layout
 
     def _define_online_indicator_layout(self):

--- a/bapsf_motion/gui/configure/drive_overlay.py
+++ b/bapsf_motion/gui/configure/drive_overlay.py
@@ -137,8 +137,7 @@ class AxisConfigWidget(QWidget):
             alignment=Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
         )
         layout.addSpacing(12)
-        layout.addWidget(ip_label)
-        layout.addWidget(self.ip_widget)
+        layout.addLayout(self._define_ip_input_layout())
         layout.addLayout(self._define_vdivider_layout())
         layout.addWidget(self.cm_per_rev_widget)
         layout.addWidget(cm_per_rev_label)
@@ -160,6 +159,26 @@ class AxisConfigWidget(QWidget):
         layout.addSpacing(8)
         layout.addWidget(divider)
         layout.addSpacing(8)
+        return layout
+
+    def _define_ip_input_layout(self):
+        _label = QLabel("IP:", parent=self)
+        font = _label.font()
+        font.setPointSize(16)
+        _label.setFont(font)
+        ip_label = _label
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(
+            ip_label,
+            alignment=Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter,
+        )
+        layout.addSpacing(4)
+        layout.addWidget(
+            self.ip_widget,
+            alignment=Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+        )
         return layout
 
     def _define_limit_mode_layout(self):

--- a/bapsf_motion/gui/configure/helpers.py
+++ b/bapsf_motion/gui/configure/helpers.py
@@ -27,7 +27,7 @@ gui_logger_config_dict = {
     "handlers": {
         "stdout": {
             "class": "logging.StreamHandler",
-            "level": "WARNING",
+            "level": "INFO",
             "formatter": "default",
             "stream": "ext://sys.stdout",
         },

--- a/bapsf_motion/gui/widgets/__init__.py
+++ b/bapsf_motion/gui/widgets/__init__.py
@@ -46,8 +46,8 @@ from bapsf_motion.gui.widgets.misc import (
     BatteryStatusIcon,
     HLinePlain,
     IPv4Validator,
+    QDoublePinnedValidator,
     QLineEditSpecialized,
     QTAIconLabel,
     VLinePlain,
-    QDoublePinnedValidator,
 )

--- a/bapsf_motion/gui/widgets/__init__.py
+++ b/bapsf_motion/gui/widgets/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "IconButton",
     "IPv4Validator",
     "LED",
+    "QDoublePinnedValidator",
     "QLineEditSpecialized",
     "QLogger",
     "QLogHandler",
@@ -48,4 +49,5 @@ from bapsf_motion.gui.widgets.misc import (
     QLineEditSpecialized,
     QTAIconLabel,
     VLinePlain,
+    QDoublePinnedValidator,
 )

--- a/bapsf_motion/gui/widgets/misc.py
+++ b/bapsf_motion/gui/widgets/misc.py
@@ -7,11 +7,14 @@ __all__ = [
     "QTAIconLabel",
     "HLinePlain",
     "VLinePlain",
+    "QDoublePinnedValidator"
 ]
 
+import ast
 import logging
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QDoubleValidator
 from PySide6.QtWidgets import QLabel
 
 # import of qtawesome and bapsf_qt must happen after the PySide6 imports
@@ -49,3 +52,20 @@ class BatteryStatusIcon(QLabel):
             _icon = self._icon_map["unknown"]
 
         self.setPixmap(_icon.pixmap(self._pixmap_size, self._pixmap_size))
+
+
+class QDoublePinnedValidator(QDoubleValidator):
+    def fixup(self, input, /):
+        min_value = self.bottom()
+        max_value = self.top()
+
+        value = ast.literal_eval(input)
+
+        if not isinstance(value, (float, int)):
+            return input
+
+        if value < min_value:
+            return f"{min_value}"
+
+        if value > max_value:
+            return f"{max_value}"

--- a/bapsf_motion/gui/widgets/misc.py
+++ b/bapsf_motion/gui/widgets/misc.py
@@ -7,7 +7,7 @@ __all__ = [
     "QTAIconLabel",
     "HLinePlain",
     "VLinePlain",
-    "QDoublePinnedValidator"
+    "QDoublePinnedValidator",
 ]
 
 import ast


### PR DESCRIPTION
This PR updates `Motor` and `AxisConfigWidget` so the motor speed (in rev/s) can be adjusted during `Motor` instantiation and during a `ConfigureGUI` session.

---

- Added commands to `Motor`
  - `set_limit_mode` : method command that allows you to set the limit mode of the motor without having to used `"DL"` directly
  - `set_speeds` : method command that allows you to set the motor move and jog speeds
- Changed `Motor.motor["DEFAULT"]["speed"]` to 4.0 rev/s
- Added key `"define_limits"` to `Motor.motor["DEFAULT"]`, which is set to 1.
- `set_limit_mode` and `set_speeds` are now used by `_configure_before_run()` and `_configure_motor()`.
- Key `"speed"` is added to `Motor.config`.

<br>

- `AxisConfigWidget` is refactored to better compartmentalize code to make it easier to modify (i.e. add new controls).
- `AxisConfigWidget` : added configuration for the motor speed.  Unlike the previous configuration widgets, the speed configuration does NOT cause a new `Axis` actor to be spawned for verification.  If a valid `Axis` actor is running, then the speed setting is changed and then confirmed by checking `Axis.motor.config`
- `AxisConfigWidget` : Configuring limit mode is setup to behave like configuring speed.  A new `Axis` actor is not spawned, instead the mode is set directly on `Axis.motor` and then confirmed in `Axis.motor.config`.

<br>

- Created `QDoublePinnedValidator`, which inherits from `QDoubleValidator` but overrides the `fixup()` method to pin user input value to `bottom()` or `top()` if the input was out of range.