### PR TITLE
Patch for known MALFORMED return string from the STM Applied Motion motors

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1465,7 +1465,35 @@ class Motor(EventActor):
 
         recv_pattern = self._commands[command]["recv"]
         if recv_pattern is not None:
-            rtn_str = recv_pattern.fullmatch(rtn_str).group("return")
+            # We have observed motors returing a MALFORMED string where
+            # the correct string is returned with a leading digit (generall 1).
+            #
+            # For example, 'AL=0004' would be returned as '1AL=0004'.
+            #
+            # This behavior is unexpected, and could not be found in the
+            # Host-Commands reference document.
+            #
+            # Let's modify all regex patterns to handle this specific case.
+            #
+            recv_pattern = re.compile(r"(?P<bad_leader>[0-9]]?)" + recv_pattern.pattern)
+            match = recv_pattern.fullmatch(rtn_str)
+            try:
+                rtn_str = match.group("return")
+            except AttributeError:
+                # the return string did not match the expected regex
+                self.logger.error(
+                    f"The return string for command '{command} ({_send_str})'"
+                    f" is malformed, received '{rtn_str}'."
+                )
+                return self.ack_flags.MALFORMED
+            else:
+                bad_leader = match.group("bad_leader")
+                if bad_leader == "":
+                    self.logger.warning(
+                        f"The returned string for command '{command}' had a bad "
+                        f"leading digit '{bad_leader}'.  The full returned string "
+                        f"was '{match.string}'."
+                    )
 
         processor = self._commands[command]["recv_processor"]
         rtn = processor(rtn_str)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1465,8 +1465,8 @@ class Motor(EventActor):
 
         recv_pattern = self._commands[command]["recv"]
         if recv_pattern is not None:
-            # We have observed motors returing a MALFORMED string where
-            # the correct string is returned with a leading digit (generall 1).
+            # We have observed motors returning a MALFORMED string where
+            # the correct string is returned with a leading digit (generally 1).
             #
             # For example, 'AL=0004' would be returned as '1AL=0004'.
             #


### PR DESCRIPTION
A case has been observed where the STM Applied Motion motor returns a response with the expected regex pattern except it has a leading digit.  For example, an `"AL"` command would expect a response like `"AL=0004"` but would get `"1AL=0004"`.

Since this is a handleable offense, `Motor._process_command_return_string()` will now prepend any command received regex pattern with `r"(?P<bad_leader>[0-9]?)"`.  If this scenario happens, a log warning will be issued but functionality will continue.

Additionally, `Motor._process_command_return_string()` is updated to better manage if a regex pattern is not matched at all.

---

> [!IMPORTANT]
> Update 20260612:  I believe I've found the culprit for this "malformed" string.  If bit 1 (`Address Character - always send address character`) of the protocol command (`PR2`) is set high, then all drive responses will be returned with the drive address character.  Thus, a command like `VE` would retrun `1VE=50` instead of `VE=50`.  Valid address characters are `! “ # $ % & ‘ ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < > ? @`, and the address characters is settable using the `DA` command.