### PR TITLE
Add CLI debug flag `--debug` to `bapsf_motion.gui.configure`

### DIFF
--- a/bapsf_motion/gui/configure/__init__.py
+++ b/bapsf_motion/gui/configure/__init__.py
@@ -3,10 +3,12 @@ Module containing all the elements for the Configuration GUI.
 """
 
 __all__ = ["ConfigureGUI"]
+
 from bapsf_motion.gui.configure.configure_ import ConfigureGUI
 
 if __name__ == "__main__":
     import argparse
+    import os
     import pathlib
 
     # from PySide6.QtWidgets import QApplication
@@ -29,26 +31,43 @@ if __name__ == "__main__":
         default=None,
         type=pathlib.Path,
     )
+    default_debug = (
+            "*.debug=true;"
+            "qt.text.emojisegmenter.debug=false;"
+            "qt.widgets.showhide.debug=false"
+        )
+    parser.add_argument(
+        "--debug",
+        nargs="?",
+        const=default_debug,
+        type=str,
+        default=None,
+        help=(
+            "Sets the QT_LOGGING_RULES environment variable.  If not "
+            f"specified, then will default to '{default_debug}'."
+        ),
+    )
     args = parser.parse_args()
 
+    # Hanlde --default-file
     if args.defaults_file is not None and not args.defaults_file.exists():
         args.defaults_file = None
     elif args.defaults_file is not None:
         args.defaults_file = args.defaults_file.resolve()
 
+    # Hanlde --config-file
     if args.config_file is not None and not args.config_file.exists():
         args.config_file = None
     elif args.config_file is not None:
         args.config_file = args.config_file.resolve()
 
-    # app = QApplication([])
-    #
-    # window = ConfigureGUI(
-    #     config=args.config_file,
-    #     defaults=args.defaults_file,
-    # )
-    # window.show()
+    # Hanlde --debug
+    if args.debug is not None:
+        os.environ["SHIBOKEN_DEBUG"] = "1"
+        os.environ["QT_DEBUG_PLUGINS"] = "1"
+        os.environ["QT_LOGGING_RULES"] = args.debug
 
+    # Launch App
     app = ConfigureApp(
         [],
         config=args.config_file,

--- a/bapsf_motion/gui/configure/__init__.py
+++ b/bapsf_motion/gui/configure/__init__.py
@@ -49,19 +49,19 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Hanlde --default-file
+    # Handle --default-file
     if args.defaults_file is not None and not args.defaults_file.exists():
         args.defaults_file = None
     elif args.defaults_file is not None:
         args.defaults_file = args.defaults_file.resolve()
 
-    # Hanlde --config-file
+    # Handle --config-file
     if args.config_file is not None and not args.config_file.exists():
         args.config_file = None
     elif args.config_file is not None:
         args.config_file = args.config_file.resolve()
 
-    # Hanlde --debug
+    # Handle --debug
     if args.debug is not None:
         os.environ["SHIBOKEN_DEBUG"] = "1"
         os.environ["QT_DEBUG_PLUGINS"] = "1"

--- a/bapsf_motion/gui/configure/__init__.py
+++ b/bapsf_motion/gui/configure/__init__.py
@@ -32,10 +32,10 @@ if __name__ == "__main__":
         type=pathlib.Path,
     )
     default_debug = (
-            "*.debug=true;"
-            "qt.text.emojisegmenter.debug=false;"
-            "qt.widgets.showhide.debug=false"
-        )
+        "*.debug=true;"
+        "qt.text.emojisegmenter.debug=false;"
+        "qt.widgets.showhide.debug=false"
+    )
     parser.add_argument(
         "--debug",
         nargs="?",


### PR DESCRIPTION
This PR adds to the runner in `bapsf_motion.gui.configure` a debug flag `--debug`.

This debug flag sets three environment variables: 
- `SHIBOKEN_DEBUG="1"`
- `QT_DEBUG_PLUGINS="1"`
- `QT_LOGGING_RULES="*.debug=true;qt.text.emojisegmenter.debug=false;qt.widgets.showhide.debug=false"`

The `--debug` flag can be giving without any arguments, which defaults to what is written above.  It can also be given a argument that will be set to `QT_LOGGING_RULES`.

This will cause the Qt backend to issue more verbose debug logs, which can be helpful for tracing bugs that do not have good reporting by default.