### PR TITLE
Patch `"speed"` population of `Motor.config`

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1009,7 +1009,11 @@ class Motor(EventActor):
         speed = self.motor["speed"]
         if isinstance(speed, u.Quantity):
             speed = speed.value
-        speed = float(speed)
+        try:
+            speed = float(speed)
+        except TypeError:
+            # Motor is likely connected and the stored value is an AckFlags
+            speed = 0.0
 
         return {
             "name": self.name,


### PR DESCRIPTION
The `"speed"` key in `Motor.config` is populated from the `Motor.motor` dictionary, which is updated when commands are sent to the motor and relevant responses are received.  This can lead to scenarios where `Motor.motor["speed"]` is `None` or an `AckFlags` enum.  These both raise `TypeError` when forcing `Motor.config["speed"]` to be a `float()`.  If this happens, the speed value now defaults to zero, `0.0`.