### PR TITLE
Ensure targetPositionChanged is always emitted with a list

### DIFF
--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -577,7 +577,10 @@ class AxisControlWidget(QWidget):
 
     @Slot()
     def _validate_target_position_value(self):
-        self.targetPositionChanged.emit(self.target_position)
+        target_position = self.target_position
+        if not isinstance(target_position, list):
+            target_position = []
+        self.targetPositionChanged.emit(target_position)
 
     @Slot()
     def _zero_axis(self):
@@ -840,10 +843,10 @@ class DriveBaseController(QWidget):
     @Slot()
     def _target_position_changed(self, position):
         self.logger.info(f"DBC target position changed {self.target_position}")
-        tpos = self.target_position
-        if tpos is None:
-            tpos = []
-        self.targetPositionChanged.emit(tpos)
+        target_position = self.target_position
+        if target_position is None:
+            target_position = []
+        self.targetPositionChanged.emit(target_position)
 
     def link_motion_group(self, mg: MotionGroup):
         if not isinstance(mg, MotionGroup):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1386,6 +1386,8 @@ class MGWidget(QWidget):
         self.drive_control_widget.link_motion_group(self.mg)
 
         target_position = self.drive_control_widget.target_position
+        if not isinstance(target_position, list):
+            target_position = []
         self.drive_control_widget.targetPositionChanged.emit(target_position)
 
         self._update_position_in_plot()


### PR DESCRIPTION
Recently `ConfigureGUI` was logging a `Shiboken::Conversions` error (see below).  This was a results of the `targetPositionChanged` signal being given a `None` payload instead of its required `list` payload.  This PR updates the current code to ensure the signal is emitted with an empty list `[]` instead of `None`.

<img width="789" height="42" alt="image" src="https://github.com/user-attachments/assets/6aea6e31-2805-4034-8cc1-6fec374f9f8e" />