### PR TITLE
Handle Motor response that is prepended with Address Characer

### DIFF
--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1456,24 +1456,29 @@ class Motor(EventActor):
 
         _send_str = self._commands[command]["send"]
 
-        if "%" in rtn_str:
+        is_ack_nack_response = _send_str not in rtn_str
+        addr_char_regex = r"""(?P<addr_char>[!"#$%&'()*+,-./0-9:;<>?@]?)"""
+        if is_ack_nack_response and bool(re.fullmatch(addr_char_regex + r"%", rtn_str)):
             # Motor acknowledge and executed command.
             return self.ack_flags.ACK
-        elif "*" in rtn_str:
+        elif is_ack_nack_response and bool(re.fullmatch(addr_char_regex + r"*", rtn_str)):
             # Motor acknowledged command and buffered it into the queue
             return self.ack_flags.ACK_QUEUED
-        elif "?" in rtn_str:
+        elif is_ack_nack_response and bool(
+            match := re.fullmatch(addr_char_regex + r"\?(?P<code>\d{0,2})", rtn_str)
+        ):
             # Motor negatively acknowledge command, error in command
-            err_code = (
-                re.compile(r"\d?\?(?P<code>\d{1,2})").fullmatch(rtn_str).group("code")
-            )
-            err_code = int(err_code)
-            err_msg = f"{err_code} - {self._nack_codes[err_code]}"
+            err_code = match.group("code")
+            if err_code == "":
+                err_msg = "unspecified"
+            else:
+                err_code = int(err_code)
+                err_msg = f"{err_code} - {self._nack_codes[err_code]}"
             self.logger.error(
                 f"Motor returned Nack from command {command} with error: {err_msg}."
             )
             return self.ack_flags.NACK
-        elif not isinstance(rtn_str, str) or _send_str not in rtn_str:
+        elif not isinstance(rtn_str, str) or is_ack_nack_response:
             self.logger.error(
                 f"The return string for command '{command} ({_send_str})'"
                 f" is malformed, received '{rtn_str}'."
@@ -1492,7 +1497,9 @@ class Motor(EventActor):
             #
             # Let's modify all regex patterns to handle this specific case.
             #
-            recv_pattern = re.compile(r"(?P<bad_leader>[0-9]?)" + recv_pattern.pattern)
+            recv_pattern = re.compile(
+                r"""(?P<addr_char>[!"#$%&'()*+,-./0-9:;<>?@]?)""" + recv_pattern.pattern
+            )
             match = recv_pattern.fullmatch(rtn_str)
             try:
                 rtn_str = match.group("return")
@@ -1503,14 +1510,6 @@ class Motor(EventActor):
                     f" is malformed, received '{rtn_str}'."
                 )
                 return self.ack_flags.MALFORMED
-            else:
-                bad_leader = match.group("bad_leader")
-                if bad_leader != "":
-                    self.logger.warning(
-                        f"The returned string for command '{command}' had a bad "
-                        f"leading digit '{bad_leader}'.  The full returned string "
-                        f"was '{match.string}'."
-                    )
 
         processor = self._commands[command]["recv_processor"]
         rtn = processor(rtn_str)

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1296,7 +1296,7 @@ class Motor(EventActor):
             self.start_heartbeat()
 
         cmd_str = self._process_command(command, *args)
-        recv_str = cmd_str if "?" in cmd_str else self._send_raw_command(cmd_str)
+        recv_str = cmd_str if "?3" == cmd_str else self._send_raw_command(cmd_str)
 
         if self._lost_connection(recv_str):
             self.logger.error(

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1492,7 +1492,7 @@ class Motor(EventActor):
                 return self.ack_flags.MALFORMED
             else:
                 bad_leader = match.group("bad_leader")
-                if bad_leader == "":
+                if bad_leader != "":
                     self.logger.warning(
                         f"The returned string for command '{command}' had a bad "
                         f"leading digit '{bad_leader}'.  The full returned string "

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1487,15 +1487,8 @@ class Motor(EventActor):
 
         recv_pattern = self._commands[command]["recv"]
         if recv_pattern is not None:
-            # We have observed motors returning a MALFORMED string where
-            # the correct string is returned with a leading digit (generally 1).
-            #
-            # For example, 'AL=0004' would be returned as '1AL=0004'.
-            #
-            # This behavior is unexpected, and could not be found in the
-            # Host-Commands reference document.
-            #
-            # Let's modify all regex patterns to handle this specific case.
+            # Let's modify all regex patterns to handle motro responses that
+            # are prepended with the motor address character.
             #
             recv_pattern = re.compile(
                 r"""(?P<addr_char>[!"#$%&'()*+,-./0-9:;<>?@]?)""" + recv_pattern.pattern

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -1479,7 +1479,7 @@ class Motor(EventActor):
             #
             # Let's modify all regex patterns to handle this specific case.
             #
-            recv_pattern = re.compile(r"(?P<bad_leader>[0-9]]?)" + recv_pattern.pattern)
+            recv_pattern = re.compile(r"(?P<bad_leader>[0-9]?)" + recv_pattern.pattern)
             match = recv_pattern.fullmatch(rtn_str)
             try:
                 rtn_str = match.group("return")

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -368,6 +368,19 @@ class Motor(EventActor):
             two_way=True,
             units=u.rev / u.s / u.s,
         ),
+        "define_address": CommandEntry(
+            "define_address",
+            send="DA",
+            send_processor=lambda value: (
+                "" if (
+                    match := re.fullmatch(r"""[!"#$%&'()*+,-./0-9:;<>?@]""", f"{value}")
+                ) is None
+                else match.group(0)
+            ),
+            recv=re.compile(r"""DA=(?P<return>[!"#$%&'()*+,-./0-9:;<>?@])"""),
+            recv_processor=str,
+            two_way=True,
+        ),
         "define_limits": CommandEntry(
             "define_limits",
             send="DL",

--- a/bapsf_motion/actors/motor_.py
+++ b/bapsf_motion/actors/motor_.py
@@ -372,9 +372,9 @@ class Motor(EventActor):
             "define_address",
             send="DA",
             send_processor=lambda value: (
-                "" if (
-                    match := re.fullmatch(r"""[!"#$%&'()*+,-./0-9:;<>?@]""", f"{value}")
-                ) is None
+                ""
+                if (match := re.fullmatch(r"""[!"#$%&'()*+,-./0-9:;<>?@]""", f"{value}"))
+                is None
                 else match.group(0)
             ),
             recv=re.compile(r"""DA=(?P<return>[!"#$%&'()*+,-./0-9:;<>?@])"""),


### PR DESCRIPTION
Resolves #181 

This PR updates the `Motor` class so it can handle response messages that are prepended with the motor address character.

---

- Added motor command `"define_address"`, which sets the address character.
- Updated the regex matching done in `Motor._process_command_return_string()` to handle motor responses with and without the address character.