### PR TITLE
In `ConfigurGUI` restrict `SimpleSignals` to only emit `PySide6` Signals

### DIFF
--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -64,6 +64,7 @@ class AxisControlWidget(QWidget):
     targetPositionChanged = Signal(float)
     lostConnection = Signal()
     establishedConnection = Signal()
+    requestDisplayRefresh = Signal()
 
     def __init__(
         self,
@@ -145,6 +146,8 @@ class AxisControlWidget(QWidget):
 
         self.establishedConnection.connect(self._handle_connection_established)
         self.lostConnection.connect(self._handle_connection_lost)
+
+        self.requestDisplayRefresh.connect(self.update_display_of_axis_status)
 
     def _define_layout(self):
         layout = QVBoxLayout()
@@ -619,11 +622,11 @@ class AxisControlWidget(QWidget):
             self._emit_connection_established
         )
         axis.motor.signals.connection_lost.connect(self._emit_connection_lost)
-        axis.motor.signals.status_changed.connect(self.update_display_of_axis_status)
+        axis.motor.signals.status_changed.connect(self.requestDisplayRefresh.emit)
         axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
         axis.motor.signals.movement_started.connect(self._emit_movement_started)
         axis.motor.signals.movement_finished.connect(self._emit_movement_finished)
-        axis.motor.signals.movement_finished.connect(self.update_display_of_axis_status)
+        axis.motor.signals.movement_finished.connect(self.requestDisplayRefresh.emit)
 
         self.update_display_of_axis_status()
         self.axisLinked.emit()
@@ -637,13 +640,13 @@ class AxisControlWidget(QWidget):
             )
             axis.motor.signals.connection_lost.disconnect(self._emit_connection_lost)
             axis.motor.signals.status_changed.disconnect(
-                self.update_display_of_axis_status
+                self.requestDisplayRefresh.emit
             )
             axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
             axis.motor.signals.movement_started.disconnect(self._emit_movement_started)
             axis.motor.signals.movement_finished.disconnect(self._emit_movement_finished)
             axis.motor.signals.movement_finished.disconnect(
-                self.update_display_of_axis_status
+                self.requestDisplayRefresh.emit
             )
 
         self._mg = None
@@ -721,7 +724,7 @@ class AxisControlWidget(QWidget):
             )
             self.axis.motor.signals.connection_lost.disconnect(self._emit_connection_lost)
             self.axis.motor.signals.status_changed.disconnect(
-                self.update_display_of_axis_status
+                self.requestDisplayRefresh.emit
             )
             self.axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
             self.axis.motor.signals.movement_started.disconnect(
@@ -731,7 +734,7 @@ class AxisControlWidget(QWidget):
                 self._emit_movement_finished
             )
             self.axis.motor.signals.movement_finished.disconnect(
-                self.update_display_of_axis_status
+                self.requestDisplayRefresh.emit
             )
 
         event.accept()

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -639,9 +639,7 @@ class AxisControlWidget(QWidget):
                 self._emit_connection_established
             )
             axis.motor.signals.connection_lost.disconnect(self._emit_connection_lost)
-            axis.motor.signals.status_changed.disconnect(
-                self.requestDisplayRefresh.emit
-            )
+            axis.motor.signals.status_changed.disconnect(self.requestDisplayRefresh.emit)
             axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
             axis.motor.signals.movement_started.disconnect(self._emit_movement_started)
             axis.motor.signals.movement_finished.disconnect(self._emit_movement_finished)


### PR DESCRIPTION
`ConfigureGUI` as getting random segmentation faults when a motor was moving.  This was linked back to to `Motor` `SimpleSignals` being connected to `AxisControlWidget.update_display_of_axis_status`.  This is inherently an unsafe thread operation since the `AxisControlWidget` is running in a thread managed by `Qt`, whereas the `SimpleSingal` could have been executed in the thread running the `Motor`'s `asyncio` loop.

This PR changes what is connected to the `SimpleSignal` to only be a Qt signal.  Thus, we're triggering `update_display_of_axis_status` to run in the Qt thread instead of running it in the `asyncio` loop thread.  **This is still inherently not thread safe, but will mitigate the chances of two threads trying to access the same memory space.**

---

- Crated signal `AxisControlWidget.requestDisplayRefresh`.
- Removed `AxisControlWidget.update_display_of_axis_status` from its connection to `Motor.signals.status_changed` and `movement_finished`.
- Connected `requestDisplayRefresh.emit` to `Motor.signals.status_changed` and `movement_finished`.