### PR TITLE
Fix `Shiboken::Conversion` errors associated with `AxisControlWidget.targetPositionChanged`

### DIFF
--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -842,7 +842,7 @@ class DriveBaseController(QWidget):
 
         return target_position
 
-    @Slot()
+    @Slot(float)
     def _target_position_changed(self, position):
         self.logger.info(f"DBC target position changed {self.target_position}")
         target_position = self.target_position

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -581,8 +581,9 @@ class AxisControlWidget(QWidget):
     @Slot()
     def _validate_target_position_value(self):
         target_position = self.target_position
-        if not isinstance(target_position, list):
-            target_position = []
+        if not isinstance(target_position, float):
+            # do nothing, no valid target position
+            return
         self.targetPositionChanged.emit(target_position)
 
     @Slot()


### PR DESCRIPTION
The `AxisControlWidget.targetPositionChanged` signal was incorrectly being populated with an `list` instead of a `float`.  This PR remedies that.

Additionally, `DriveBaseController._target_position_changed` is a slot connected to `AxisControlWidget.targetPositionChanged` so the decorated `@Slot()` is updated to represent the receiving of a `float` (i.e. `@Slot(float)`).