### PR TITLE
Add blocking to `SimpleSignal`

### DIFF
--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -90,7 +90,10 @@ class SimpleSignal:
         for handler in self.handlers:
             handler()
 
-    def set_block(self, block: bool):
+    def set_blocking(self, block: bool):
+        """
+        Set the signal to be blocked `True` or not `False`.
+        """
         if not isinstance(block, bool):
             return
 

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -37,7 +37,7 @@ class SimpleSignal:
     A very simple, rudimentary class for creating signals.
     """
 
-    def __index__(self):
+    def __init__(self):
         self._handlers = None
 
     @property

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -52,7 +52,7 @@ class SimpleSignal:
     def is_blocking(self) -> bool:
         """
         `True` if the signal is currently blocked.  That is, no
-        ``handlers`` will be exectuted on an ``emit``.
+        ``handlers`` will be executed on an ``emit``.
         """
         return self._block
 

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -37,7 +37,8 @@ class SimpleSignal:
     A very simple, rudimentary class for creating signals.
     """
 
-    _handlers = None
+    def __index__(self):
+        self._handlers = None
 
     @property
     def handlers(self) -> Union[None, List[Callable]]:

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -48,6 +48,14 @@ class SimpleSignal:
             self._handlers = []
         return self._handlers
 
+    @property
+    def is_blocking(self) -> bool:
+        """
+        `True` if the signal is currently blocked.  That is, no
+        ``handlers`` will be exectuted on an ``emit``.
+        """
+        return self._block
+
     def connect(self, func: Callable):
         """
         Connect the callback/handler ``func`` to the signal.  The

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -39,6 +39,7 @@ class SimpleSignal:
 
     def __init__(self):
         self._handlers = None
+        self._block = False
 
     @property
     def handlers(self) -> Union[None, List[Callable]]:
@@ -75,8 +76,17 @@ class SimpleSignal:
 
     def emit(self):
         """Emit the signal, which executes all the connected handlers."""
+        if self._block:
+            return
+
         for handler in self.handlers:
             handler()
+
+    def set_block(self, block: bool):
+        if not isinstance(block, bool):
+            return
+
+        self._block = block
 
 
 def load_example(filename: str, as_string=False):

--- a/bapsf_motion/utils/__init__.py
+++ b/bapsf_motion/utils/__init__.py
@@ -20,7 +20,7 @@ from astropy import units
 from collections import UserDict
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 from bapsf_motion.utils import exceptions, toml
 from bapsf_motion.utils.units_ import counts, rev, steps, units
@@ -42,7 +42,7 @@ class SimpleSignal:
         self._block = False
 
     @property
-    def handlers(self) -> Union[None, List[Callable]]:
+    def handlers(self) -> List[Callable]:
         """List of callbacks/handlers connect to the signal."""
         if self._handlers is None:
             self._handlers = []


### PR DESCRIPTION
This PR adds signal blocking to `SimpleSignal` (i.e. `SimpleSignal.set_blocking`).

Additionally, `_handlers` is made an instance attribute instead of a class attribute.

---

- Added property `is_blocking`.
- Added method `set_blocking`.
- If blocking, then no `handlers` will be executed when `SimpleSignal.emit()` is called.
- Class attribute `_handlers` is changed to an instance attribute.