### PR TITLE
Create abstract base meta class `_ABCMetaQWidget`

### DIFF
--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -15,7 +15,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QColor, QPainter, QPen
 from PySide6.QtWidgets import QSizePolicy, QWidget
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 from bapsf_motion.actors import MotionGroup
 from bapsf_motion.gui.configure import motion_group_widget as mgw
@@ -99,7 +99,7 @@ class _ConfigOverlay(_OverlayWidget, ABC, metaclass=_ABCMetaQWidget):
     returnConfig = Signal(object)
 
     def __init__(
-        self, mg: Union[MotionGroup, None], parent: "mgw.MGWidget | None" = None
+        self, mg: MotionGroup | None, parent: "mgw.MGWidget | None" = None
     ):
         super().__init__(parent=parent)
 
@@ -124,7 +124,7 @@ class _ConfigOverlay(_OverlayWidget, ABC, metaclass=_ABCMetaQWidget):
         return self._logger
 
     @property
-    def mg(self) -> Union[MotionGroup, None]:
+    def mg(self) -> MotionGroup | None:
         """Working motion group."""
         return self._mg
 

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -94,7 +94,7 @@ class _OverlayWidget(QWidget):
         event.accept()
 
 
-class _ConfigOverlay(_OverlayWidget):
+class _ConfigOverlay(_OverlayWidget, ABC, metaclass=_ABCMetaQWidget):
     configChanged = Signal()
     returnConfig = Signal(object)
 

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -98,9 +98,7 @@ class _ConfigOverlay(_OverlayWidget, ABC, metaclass=_ABCMetaQWidget):
     configChanged = Signal()
     returnConfig = Signal(object)
 
-    def __init__(
-        self, mg: MotionGroup | None, parent: "mgw.MGWidget | None" = None
-    ):
+    def __init__(self, mg: MotionGroup | None, parent: "mgw.MGWidget | None" = None):
         super().__init__(parent=parent)
 
         self._logger = gui_logger

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -30,7 +30,7 @@ class _ABCMetaQWidget(ABCMeta, type(QWidget)): ...  # noqa: E701
 class _OverlayWidget(QWidget):
     closing = Signal()
 
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget | None):
         super().__init__(parent=parent)
 
         # make the window frameless
@@ -98,7 +98,7 @@ class _ConfigOverlay(_OverlayWidget):
     configChanged = Signal()
     returnConfig = Signal(object)
 
-    def __init__(self, mg: Union[MotionGroup, None], parent: "mgw.MGWidget" = None):
+    def __init__(self, mg: Union[MotionGroup, None], parent: "mgw.MGWidget | None" = None):
         super().__init__(parent=parent)
 
         self._logger = gui_logger

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -98,7 +98,9 @@ class _ConfigOverlay(_OverlayWidget, ABC, metaclass=_ABCMetaQWidget):
     configChanged = Signal()
     returnConfig = Signal(object)
 
-    def __init__(self, mg: Union[MotionGroup, None], parent: "mgw.MGWidget | None" = None):
+    def __init__(
+        self, mg: Union[MotionGroup, None], parent: "mgw.MGWidget | None" = None
+    ):
         super().__init__(parent=parent)
 
         self._logger = gui_logger

--- a/bapsf_motion/gui/configure/bases.py
+++ b/bapsf_motion/gui/configure/bases.py
@@ -4,13 +4,14 @@ Module contains base classes for various
 """
 
 __all__ = [
+    "_ABCMetaQWidget",
     "_ConfigOverlay",
     "_OverlayWidget",
 ]
 
 import logging
 
-from abc import abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QColor, QPainter, QPen
 from PySide6.QtWidgets import QSizePolicy, QWidget
@@ -21,6 +22,9 @@ from bapsf_motion.gui.configure import motion_group_widget as mgw
 from bapsf_motion.gui.configure.helpers import gui_logger
 from bapsf_motion.gui.configure.message_boxes import WarningMessageBox
 from bapsf_motion.gui.widgets import DiscardButton, DoneButton
+
+
+class _ABCMetaQWidget(ABCMeta, type(QWidget)): ...  # noqa: E701
 
 
 class _OverlayWidget(QWidget):

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -17,7 +17,7 @@ os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"  # noqa
 
 import pygame  # noqa
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from PySide6.QtCore import Qt, QThreadPool, QTimer, Signal, Slot
 from PySide6.QtGui import QCloseEvent, QDoubleValidator, QFont
 from PySide6.QtWidgets import (
@@ -34,6 +34,7 @@ from PySide6.QtWidgets import (
 from typing import List, Literal, TYPE_CHECKING
 
 from bapsf_motion.actors import Axis, Drive, MotionGroup
+from bapsf_motion.gui.configure.bases import _ABCMetaQWidget
 from bapsf_motion.gui.configure.helpers import gui_logger
 from bapsf_motion.gui.configure.pygame_ import PyGameJoystickRunner
 from bapsf_motion.gui.icons import icon_name_dict
@@ -739,7 +740,7 @@ class AxisControlWidget(QWidget):
         event.accept()
 
 
-class DriveBaseController(QWidget):
+class DriveBaseController(QWidget, ABC, metaclass=_ABCMetaQWidget):
     driveStatusChanged = Signal()
     movementStarted = Signal()
     movementStopped = Signal()

--- a/bapsf_motion/gui/configure/motion_space_display.py
+++ b/bapsf_motion/gui/configure/motion_space_display.py
@@ -27,7 +27,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas 
 from matplotlib.backends.backend_qtagg import (  # noqa
     NavigationToolbar2QT as NavigationToolbar,
 )
-from matplotlib.collections import PathCollection
+from matplotlib.collections import PathCollection  # noqa
 
 
 class MotionSpaceDisplay(QFrame):


### PR DESCRIPTION
This PR creates a python Metaclass so we can create abstract base classes from a `QWidget` and `ABC` inheritance.

---

- Create `_ABCMetaClass`
- Set metaclass to `_ABCMetaClass` for `_ConfigOverlay`.
- Set metaclass to `_ABCMetaClass` for `DriveBaseController`.