### PR TITLE
Add `Motor` `SimpleSignal` blocking funcitonality to `ConfigureGUI` framework

### DIFF
--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -83,11 +83,13 @@ class AxisControlWidget(QWidget):
             "connection_established": [self._emit_connection_established],
             "connection_lost": [self._emit_connection_lost],
             "status_changed": [
-                self.requestDisplayRefresh.emit, self.axisStatusChanged.emit
+                self.requestDisplayRefresh.emit,
+                self.axisStatusChanged.emit,
             ],
             "movement_started": [self._emit_movement_started],
             "movement_finished": [
-                self._emit_movement_finished, self.requestDisplayRefresh.emit
+                self._emit_movement_finished,
+                self.requestDisplayRefresh.emit,
             ],
         }
 

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -46,6 +46,7 @@ from bapsf_motion.gui.widgets import (
     ValidButton,
     ZeroButton,
 )
+from bapsf_motion.utils import SimpleSignal
 from bapsf_motion.utils import units as u
 
 if TYPE_CHECKING:
@@ -77,6 +78,17 @@ class AxisControlWidget(QWidget):
 
         self._mg = None
         self._axis_index = None
+        self._motor_signal_mapping = {
+            "connection_established": [self._emit_connection_established],
+            "connection_lost": [self._emit_connection_lost],
+            "status_changed": [
+                self.requestDisplayRefresh.emit, self.axisStatusChanged.emit
+            ],
+            "movement_started": [self._emit_movement_started],
+            "movement_finished": [
+                self._emit_movement_finished, self.requestDisplayRefresh.emit
+            ],
+        }
 
         # Configure display update timer
         # - to update widgets during a motor movement
@@ -619,15 +631,7 @@ class AxisControlWidget(QWidget):
         self.axis_name_label.setText(axis.name)
 
         # connect motor SimpleSignals
-        axis.motor.signals.connection_established.connect(
-            self._emit_connection_established
-        )
-        axis.motor.signals.connection_lost.connect(self._emit_connection_lost)
-        axis.motor.signals.status_changed.connect(self.requestDisplayRefresh.emit)
-        axis.motor.signals.status_changed.connect(self.axisStatusChanged.emit)
-        axis.motor.signals.movement_started.connect(self._emit_movement_started)
-        axis.motor.signals.movement_finished.connect(self._emit_movement_finished)
-        axis.motor.signals.movement_finished.connect(self.requestDisplayRefresh.emit)
+        self.motor_signals_connect(axis)
 
         self.update_display_of_axis_status()
         self.axisLinked.emit()
@@ -636,17 +640,7 @@ class AxisControlWidget(QWidget):
         axis = self.axis
         if isinstance(axis, Axis):
             # disconnect all motor SimpleSignals
-            axis.motor.signals.connection_established.disconnect(
-                self._emit_connection_established
-            )
-            axis.motor.signals.connection_lost.disconnect(self._emit_connection_lost)
-            axis.motor.signals.status_changed.disconnect(self.requestDisplayRefresh.emit)
-            axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
-            axis.motor.signals.movement_started.disconnect(self._emit_movement_started)
-            axis.motor.signals.movement_finished.disconnect(self._emit_movement_finished)
-            axis.motor.signals.movement_finished.disconnect(
-                self.requestDisplayRefresh.emit
-            )
+            self.motor_signals_disconnect(axis)
 
         self._mg = None
         self._axis_index = None
@@ -714,27 +708,60 @@ class AxisControlWidget(QWidget):
         self.jog_backward_btn.setEnabled(False)
         self.enable_btn.setEnabled(False)
 
+    def motor_signals_connect(self, axis: Axis | None = None):
+        if axis is None:
+            axis = self.axis
+
+        if not isinstance(axis, Axis):
+            return
+
+        for motor_signal, callbacks in self._motor_signal_mapping.items():
+            signal = getattr(axis.motor.signals, motor_signal, None)
+
+            if not isinstance(signal, SimpleSignal):
+                continue
+
+            for callback in callbacks:
+                signal.connect(callback)
+
+    def motor_signals_disconnect(self, axis: Axis | None = None):
+        if axis is None:
+            axis = self.axis
+
+        if not isinstance(axis, Axis):
+            return
+
+        for motor_signal, callbacks in self._motor_signal_mapping.items():
+            signal = getattr(axis.motor.signals, motor_signal, None)
+
+            if not isinstance(signal, SimpleSignal):
+                continue
+
+            for callback in callbacks:
+                signal.disconnect(callback)
+
+    def motor_signals_set_blocking(self, block: bool, axis: Axis | None = None):
+        if not isinstance(block, bool):
+            return
+
+        if axis is None:
+            axis = self.axis
+
+        if not isinstance(axis, Axis):
+            return
+
+        for motor_signal in self._motor_signal_mapping.keys():
+            signal = getattr(axis.motor.signals, motor_signal, None)
+
+            if not isinstance(signal, SimpleSignal):
+                continue
+
+            signal.set_blocking(block)
+
     def closeEvent(self, event: QCloseEvent):
         self.logger.info("Closing AxisControlWidget")
 
-        if isinstance(self.axis, Axis):
-            self.axis.motor.signals.connection_established.disconnect(
-                self._emit_connection_established
-            )
-            self.axis.motor.signals.connection_lost.disconnect(self._emit_connection_lost)
-            self.axis.motor.signals.status_changed.disconnect(
-                self.requestDisplayRefresh.emit
-            )
-            self.axis.motor.signals.status_changed.disconnect(self.axisStatusChanged.emit)
-            self.axis.motor.signals.movement_started.disconnect(
-                self._emit_movement_started
-            )
-            self.axis.motor.signals.movement_finished.disconnect(
-                self._emit_movement_finished
-            )
-            self.axis.motor.signals.movement_finished.disconnect(
-                self.requestDisplayRefresh.emit
-            )
+        self.motor_signals_disconnect()
 
         event.accept()
 

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -750,6 +750,10 @@ class AxisControlWidget(QWidget):
         if not isinstance(axis, Axis):
             return
 
+        self.logger.info(
+            f"<--{self.axis_name_label.text()}--> Set motor blocking to {block}."
+        )
+
         for motor_signal in self._motor_signal_mapping.keys():
             signal = getattr(axis.motor.signals, motor_signal, None)
 

--- a/bapsf_motion/gui/configure/controllers.py
+++ b/bapsf_motion/gui/configure/controllers.py
@@ -1003,6 +1003,13 @@ class DriveBaseController(QWidget):
 
         self._mspace_drive_polarity = polarity
 
+    def motor_signals_set_blocking(self, block: bool):
+        if not isinstance(block, bool):
+            return
+
+        for acw in self._axis_control_widgets:
+            acw.motor_signals_set_blocking(block)
+
     def closeEvent(self, event):
         self.logger.info(f"Closing {self.__class__.__name__}.")
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -338,10 +338,14 @@ class DriveControlWidget(QWidget):
 
     def setDisabled(self, disable: bool):
         self.lost_connection_dialog.setDisabled(disable)
+        self.motor_signals_set_blocking(disable)
+
         super().setDisabled(disable)
 
     def setEnabled(self, enable: bool):
         self.lost_connection_dialog.setEnabled(enable)
+        self.motor_signals_set_blocking(not enable)
+
         super().setEnabled(enable)
 
     def motor_signals_set_blocking(self, block: bool):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1406,7 +1406,9 @@ class MGWidget(QWidget):
     @Slot(object)
     def _handle_motion_builder_overlay_close(self, config: Dict[str, Any]):
         if len(config) == 0:
-            # no config returned, do nothing
+            # no config returned, just emit configChanged to refresh
+            # widget visibility and enable-ness
+            self.configChanged.emit()
             return
 
         self._change_motion_builder(config)
@@ -1414,7 +1416,9 @@ class MGWidget(QWidget):
     @Slot(object)
     def _handle_transform_overlay_close(self, config: Dict[str, Any]):
         if len(config) == 0:
-            # no config returned, do nothing
+            # no config returned, just emit configChanged to refresh
+            # widget visibility and enable-ness
+            self.configChanged.emit()
             return
 
         self._change_transform(config)

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1910,7 +1910,6 @@ class MGWidget(QWidget):
 
         self.drive_control_widget.setEnabled(False)
         self.mspace_display.setEnabled(False)
-        self.mspace_display.setVisible(False)
 
     @Slot()
     def discard_close(self):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -344,6 +344,11 @@ class DriveControlWidget(QWidget):
         self.lost_connection_dialog.setEnabled(enable)
         super().setEnabled(enable)
 
+    def motor_signals_set_blocking(self, block: bool):
+        self.desktop_controller_widget.motor_signals_set_blocking(block)
+        if isinstance(self.game_controller_widget, DriveGameController):
+            self.game_controller_widget.motor_signals_set_blocking(block)
+
     def closeEvent(self, event):
         self.logger.info(f"Closing {self.__class__.__name__}")
 

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1036,6 +1036,10 @@ class MGWidget(QWidget):
         self._update_ml_name_widget()
         self.blockSignals(False)
 
+        # re-enable the mspace_display, it is disabled when a popup
+        # config is launched
+        self.mspace_display.setEnabled(True)
+
         self._validate_motion_group()
 
         # now update displays

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -1239,7 +1239,7 @@ class MGWidget(QWidget):
     def _popup_drive_configuration(self):
         # disable the drive_control_widget to prevent popup of the
         # LostConnection dialog.
-        self.drive_control_widget.setEnabled(False)
+        self.set_disable_for_popup()
 
         if isinstance(self.mg, MotionGroup):
             self.mg.terminate(delay_loop_stop=True)
@@ -1254,6 +1254,8 @@ class MGWidget(QWidget):
 
     @Slot()
     def _popup_transform_configuration(self):
+        self.set_disable_for_popup()
+
         self._overlay_setup(TransformConfigOverlay(self.mg, parent=self))
 
         # overlay signals
@@ -1264,6 +1266,8 @@ class MGWidget(QWidget):
 
     @Slot()
     def _popup_motion_builder_configuration(self):
+        self.set_disable_for_popup()
+
         self._overlay_setup(MotionBuilderConfigOverlay(self.mg, parent=self))
 
         # overlay signals
@@ -1891,6 +1895,18 @@ class MGWidget(QWidget):
 
         self.returnConfig.emit(index, config)
         self.close()
+
+    def set_disable_for_popup(self):
+        mg = self.mg
+        if isinstance(mg, MotionGroup) and isinstance(mg.drive, Drive):
+            # this should never happen since the the configure gear buttons
+            # are disabled when the motor is moving ... this is here for
+            # redundancy
+            mg.stop()
+
+        self.drive_control_widget.setEnabled(False)
+        self.mspace_display.setEnabled(False)
+        self.mspace_display.setVisible(False)
 
     @Slot()
     def discard_close(self):

--- a/bapsf_motion/gui/configure/motion_group_widget.py
+++ b/bapsf_motion/gui/configure/motion_group_widget.py
@@ -337,12 +337,18 @@ class DriveControlWidget(QWidget):
         self.desktop_controller_widget.set_target_position(target_position)
 
     def setDisabled(self, disable: bool):
+        if disable != self.isEnabled():
+            return
+
         self.lost_connection_dialog.setDisabled(disable)
         self.motor_signals_set_blocking(disable)
 
         super().setDisabled(disable)
 
     def setEnabled(self, enable: bool):
+        if enable == self.isEnabled():
+            return
+
         self.lost_connection_dialog.setEnabled(enable)
         self.motor_signals_set_blocking(not enable)
 


### PR DESCRIPTION
The PR adds the ability to block the `SimpleSignal`s of `Motor`, which are then blocked when switching to the transform or motion builder popups and unblocked when returning to the main controls.

---

#### `AxisControlWidget`
- Created methods `motor_signals_connect()`, `motor_signals_disconnect()`, and `motor_signals_set_blocking()`
- The motor signal mapping utilized by the above methods is defined as an instance dictionary attribute `_motor_signal_mapping` in the `__init__`.

<br>

#### `DriveBaseController`
- Created `motor_signal_set_blocking`, which calls `AxisControlWidget.motor_signal_set_blocking` to set the blocking.

<br>

#### `DriveControlWidget`
- Created `motor_signal_set_blocking`, which communicates to `DriveDesktopController` and `DriveGameController` to set blocking.
- Methods `setEnable` and `setDisable` are updated to include setting blocking for motor signals.

<br>

#### `MGWidget`
- `_config_changed_handler` will ensure the `mspace_display` is set as enabled (since going to a popup config now disables the display)
- Created method `set_disable_for_popup`, which will send a stop signal to the motors and disable widgets so signals and updates are not done while activating the popup or working in the popup.
- `set_disable_for_popup()` is utilized for all popup configurations.
- Ensured a `configChanged` is emitted when returning from a popup configuration (regardless of if nothing changed) to ensure the enable state of `MGWidget`'s widgets is properly set.
