### PR TITLE
Go back to `pygame` (instead of `pygame-ce`)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python: [ '3.10', '3.11', '3.12', '3.13' ]
         os: [ubuntu-latest, windows-latest]
         architecture: [x64]
 

--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -4,6 +4,6 @@
 bapsf_qt
 matplotlib
 packaging
-pygame-ce >= 2.2
+pygame
 PySide6 >= 6.5.0
 qtawesome

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ gui =
   bapsf_qt
   matplotlib
   packaging
-  pygame-ce >= 2.2
+  pygame
   PySide6 >= 6.5.0
   qtawesome
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers=
   Topic :: Scientific/Engineering :: Astronomy
 
 [options]
-python_requires = >=3.10, <3.15
+python_requires = >=3.10, <3.14
 packages = find:
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
This is just to debug GUI crashes.  Rolling back dependencies to v2025.7.0 when our GUI was stable.  If this does not work, then I will need to review the `Motor` and `SimpleSignal` code.