### PR TITLE
Bump `bapsf_qt` dependency to `v2026.6.4`

### DIFF
--- a/requirements/gui.txt
+++ b/requirements/gui.txt
@@ -1,7 +1,7 @@
 # these are dependencies required to use the package
 # ought to mirror 'install_requires' under 'options' in setup.cfg
 -r install.txt
-bapsf_qt
+bapsf_qt >= 2026.6.4
 matplotlib
 packaging
 pygame-ce >= 2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
   pandas <= 2.0.3
 gui =
   # ought to mirror requirements/gui.txt
-  bapsf_qt
+  bapsf_qt >= 2026.6.4
   matplotlib
   packaging
   pygame-ce >= 2.2


### PR DESCRIPTION
Set the minimum `bapsf_qt` dependency to `v2026.6.4`.

See https://github.com/BaPSF/bapsf_qt/pull/4 for additional details.